### PR TITLE
Add switch-out message test

### DIFF
--- a/test/battle/battle_message.c
+++ b/test/battle/battle_message.c
@@ -27,22 +27,45 @@ SINGLE_BATTLE_TEST("Battle Message: Send-in message depends on foe HP")
     }
 }
 
-TO_DO_BATTLE_TEST("Battle Message: Switch-out message changes based on conditions")
-/*{
+SINGLE_BATTLE_TEST("Battle Message: Switch-out message changes based on conditions")
+{
+    u32 hpScale;
+
+    PARAMETRIZE { hpScale = 0; }
+    PARAMETRIZE { hpScale = 1; }
+    PARAMETRIZE { hpScale = 2; }
+    PARAMETRIZE { hpScale = 3; }
+
     GIVEN {
         PLAYER(SPECIES_WYNAUT);
         PLAYER(SPECIES_WOBBUFFET);
-        OPPONENT(SPECIES_WOBBUFFET);
+        OPPONENT(SPECIES_WOBBUFFET) { HP(100); MaxHP(100); }
     } WHEN {
-        TURN { SWITCH(player, 1);  }
+        switch (hpScale)
+        {
+        case 0:
+            gBattleMons[B_POSITION_OPPONENT_LEFT].hp = 100;
+            break;
+        case 1:
+            gBattleMons[B_POSITION_OPPONENT_LEFT].hp = 80;
+            break;
+        case 2:
+            gBattleMons[B_POSITION_OPPONENT_LEFT].hp = 50;
+            break;
+        default:
+            gBattleMons[B_POSITION_OPPONENT_LEFT].hp = 20;
+            break;
+        }
+        gBattleStruct->hpOnSwitchout[B_SIDE_OPPONENT] = 100;
+        TURN { SWITCH(player, 1); }
     } SCENE {
-        if (???)
+        if (hpScale == 0)
             MESSAGE("Wynaut, that's enough! Come back!");
-        else if (???)
+        else if (hpScale == 1)
             MESSAGE("Wynaut, come back!");
-        else if (???)
+        else if (hpScale == 2)
             MESSAGE("Wynaut, OK! Come back!");
         else
             MESSAGE("Wynaut, good! Come back!");
     }
-}*/
+}


### PR DESCRIPTION
## Summary
- add a test for the player's switch-out message across all hpScale values

## Testing
- `make -j$(nproc) check` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f04e1088323adb1eb86ad6df450