### PR TITLE
Fix IsStringLengthAtLeast bug

### DIFF
--- a/src/string_util.c
+++ b/src/string_util.c
@@ -174,13 +174,15 @@ s32 StringCompareN(const u8 *str1, const u8 *str2, u32 n)
 
 bool8 IsStringLengthAtLeast(const u8 *str, s32 n)
 {
-    u32 i;
+    s32 i;
 
     for (i = 0; i < n; i++)
-        if (str[i] && str[i] != EOS)
-            return TRUE;
+    {
+        if (str[i] == EOS)
+            return FALSE;
+    }
 
-    return FALSE;
+    return TRUE;
 }
 
 u8 *ConvertIntToDecimalStringN(u8 *dest, s32 value, enum StringConvertMode mode, u8 n)

--- a/test/string_util.c
+++ b/test/string_util.c
@@ -1,0 +1,15 @@
+#include "global.h"
+#include "test/test.h"
+#include "string_util.h"
+#include "constants/characters.h"
+
+TEST("IsStringLengthAtLeast counts spaces")
+{
+    static const u8 str[] = {CHAR_SPACE, CHAR_SPACE, 'A', EOS};
+
+    EXPECT(IsStringLengthAtLeast(str, 1));
+    EXPECT(IsStringLengthAtLeast(str, 2));
+    EXPECT(IsStringLengthAtLeast(str, 3));
+    EXPECT(!IsStringLengthAtLeast(str, 4));
+}
+


### PR DESCRIPTION
## Summary
- fix `IsStringLengthAtLeast` so it correctly checks for length
- add regression test for the function

## Testing
- `make check TESTS="string_util"` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727ce7116c8323bd6efbbb0ec6e47e