### PR TITLE
Fix debug menu crash with 32x32 item icons

### DIFF
--- a/include/item_icon.h
+++ b/include/item_icon.h
@@ -5,8 +5,6 @@ extern u8 *gItemIconDecompressionBuffer;
 extern u8 *gItemIcon4x4Buffer;
 
 extern const struct SpriteTemplate gItemIconSpriteTemplate;
-
-bool8 AllocItemIconTemporaryBuffers(void);
 void FreeItemIconTemporaryBuffers(void);
 void CopyItemIconPicTo4x4Buffer(const void *src, void *dest);
 u8 AddItemIconSprite(u16 tilesTag, u16 paletteTag, u16 itemId);

--- a/src/decoration.c
+++ b/src/decoration.c
@@ -2077,11 +2077,25 @@ static u8 AddDecorationIconObjectFromIconTable(u16 tilesTag, u16 paletteTag, u8 
     struct SpriteTemplate *template;
     u8 spriteId;
 
-    if (!AllocItemIconTemporaryBuffers())
+    const u32 *pic = GetDecorationIconPic(decor);
+    u32 size = GetDecompressedDataSize(pic);
+
+    gItemIconDecompressionBuffer = Alloc(size);
+    if (gItemIconDecompressionBuffer == NULL)
         return MAX_SPRITES;
 
-    DecompressDataWithHeaderWram(GetDecorationIconPic(decor), gItemIconDecompressionBuffer);
-    CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
+    gItemIcon4x4Buffer = AllocZeroed(0x200);
+    if (gItemIcon4x4Buffer == NULL)
+    {
+        Free(gItemIconDecompressionBuffer);
+        return MAX_SPRITES;
+    }
+
+    DecompressDataWithHeaderWram(pic, gItemIconDecompressionBuffer);
+    if (size > 0x120)
+        CpuCopy16(gItemIconDecompressionBuffer, gItemIcon4x4Buffer, 0x200);
+    else
+        CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
     sheet.data = gItemIcon4x4Buffer;
     sheet.size = 0x200;
     sheet.tag = tilesTag;

--- a/src/item_icon.c
+++ b/src/item_icon.c
@@ -56,9 +56,9 @@ const struct SpriteTemplate gItemIconSpriteTemplate =
 };
 
 // code
-bool8 AllocItemIconTemporaryBuffers(void)
+static bool8 AllocItemIconTemporaryBuffersBySize(u32 size)
 {
-    gItemIconDecompressionBuffer = Alloc(0x120);
+    gItemIconDecompressionBuffer = Alloc(size);
     if (gItemIconDecompressionBuffer == NULL)
         return FALSE;
 
@@ -88,7 +88,10 @@ void CopyItemIconPicTo4x4Buffer(const void *src, void *dest)
 
 u8 AddItemIconSprite(u16 tilesTag, u16 paletteTag, u16 itemId)
 {
-    if (!AllocItemIconTemporaryBuffers())
+    const void *pic = GetItemIconPic(itemId);
+    u32 size = GetDecompressedDataSize(pic);
+
+    if (!AllocItemIconTemporaryBuffersBySize(size))
     {
         return MAX_SPRITES;
     }
@@ -99,8 +102,11 @@ u8 AddItemIconSprite(u16 tilesTag, u16 paletteTag, u16 itemId)
         struct SpritePalette spritePalette;
         struct SpriteTemplate *spriteTemplate;
 
-        DecompressDataWithHeaderWram(GetItemIconPic(itemId), gItemIconDecompressionBuffer);
-        CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
+        DecompressDataWithHeaderWram(pic, gItemIconDecompressionBuffer);
+        if (size > 0x120)
+            CpuCopy16(gItemIconDecompressionBuffer, gItemIcon4x4Buffer, 0x200);
+        else
+            CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
         spriteSheet.data = gItemIcon4x4Buffer;
         spriteSheet.size = 0x200;
         spriteSheet.tag = tilesTag;
@@ -125,7 +131,10 @@ u8 AddItemIconSprite(u16 tilesTag, u16 paletteTag, u16 itemId)
 
 u8 AddCustomItemIconSprite(const struct SpriteTemplate *customSpriteTemplate, u16 tilesTag, u16 paletteTag, u16 itemId)
 {
-    if (!AllocItemIconTemporaryBuffers())
+    const void *pic = GetItemIconPic(itemId);
+    u32 size = GetDecompressedDataSize(pic);
+
+    if (!AllocItemIconTemporaryBuffersBySize(size))
     {
         return MAX_SPRITES;
     }
@@ -136,8 +145,11 @@ u8 AddCustomItemIconSprite(const struct SpriteTemplate *customSpriteTemplate, u1
         struct SpritePalette spritePalette;
         struct SpriteTemplate *spriteTemplate;
 
-        DecompressDataWithHeaderWram(GetItemIconPic(itemId), gItemIconDecompressionBuffer);
-        CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
+        DecompressDataWithHeaderWram(pic, gItemIconDecompressionBuffer);
+        if (size > 0x120)
+            CpuCopy16(gItemIconDecompressionBuffer, gItemIcon4x4Buffer, 0x200);
+        else
+            CopyItemIconPicTo4x4Buffer(gItemIconDecompressionBuffer, gItemIcon4x4Buffer);
         spriteSheet.data = gItemIcon4x4Buffer;
         spriteSheet.size = 0x200;
         spriteSheet.tag = tilesTag;


### PR DESCRIPTION
## Summary
- handle icons larger than 24x24 by allocating buffers based on size
- update item icon helper API
- adjust decoration icon loader for variable icon sizes

## Testing
- `make` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a5ebb7588323b657fe050c70d724