### PR TITLE
Add Legend Plate and Hopo Berry items

### DIFF
--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -1010,10 +1010,10 @@
 #define ITEM_IVREDUCER_SPDEF 839
 #define ITEM_IVREDUCER_SPEED 840
 
-// HOPO BERRY
-// LEGEND PLATE
+#define ITEM_HOPO_BERRY 841
+#define ITEM_LEGEND_PLATE 842
 
-#define ITEMS_COUNT 841
+#define ITEMS_COUNT 843
 #define ITEM_FIELD_ARROW ITEMS_COUNT
 
 // A special item id associated with "Cancel"/"Exit" etc. in a list of items or decorations

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -67,6 +67,7 @@ static bool32 CanBeInfinitelyConfused(u32 battler);
 static bool32 IsAnyTargetAffected(u32 battlerAtk);
 static bool32 IsNonVolatileStatusBlocked(u32 battlerDef, u32 abilityDef, u32 abilityAffected, const u8 *battleScript, enum FunctionCallOption option);
 static bool32 CanSleepDueToSleepClause(u32 battlerAtk, u32 battlerDef, enum FunctionCallOption option);
+static void TryLegendPlateJudgmentTypeChange(void);
 
 ARM_FUNC NOINLINE static uq4_12_t PercentToUQ4_12(u32 percent);
 ARM_FUNC NOINLINE static uq4_12_t PercentToUQ4_12_Floored(u32 percent);

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -14213,4 +14213,44 @@ const struct Item gItemsInfo[] =
         .iconPic = gItemIcon_IvReducerSpe,
         .iconPalette = gItemIconPalette_IvReducer,
     },
+
+    [ITEM_HOPO_BERRY] =
+    {
+        .name = _("Hopo Berry"),
+        .pluralName = _("Hopo Berries"),
+        .price = 80,
+        .holdEffect = HOLD_EFFECT_RESTORE_PP,
+        .holdEffectParam = 10,
+        .description = COMPOUND_STRING(
+            "A hold item that\n"
+            "restores 10 PP in\n"
+            "battle."),
+        .pocket = POCKET_BERRIES,
+        .type = ITEM_USE_PARTY_MENU_MOVES,
+        .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
+        .battleUsage = EFFECT_ITEM_RESTORE_PP,
+        .effect = gItemEffect_HopoBerry,
+        .flingPower = 10,
+        .iconPic = gItemIcon_QuestionMark,
+        .iconPalette = gItemIconPalette_QuestionMark,
+    },
+
+    [ITEM_LEGEND_PLATE] =
+    {
+        .name = _("Legend Plate"),
+        .price = 1000,
+        .holdEffect = HOLD_EFFECT_PLATE,
+        .holdEffectParam = 20,
+        .description = COMPOUND_STRING(
+            "A stone tablet that\n"
+            "radiates every type\n"
+            "of energy."),
+        .pocket = POCKET_BATTLE_ITEMS,
+        .type = ITEM_USE_BAG_MENU,
+        .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
+        .secondaryId = TYPE_STELLAR,
+        .flingPower = 90,
+        .iconPic = gItemIcon_QuestionMark,
+        .iconPalette = gItemIconPalette_QuestionMark,
+    },
 };

--- a/src/data/pokemon/item_effects.h
+++ b/src/data/pokemon/item_effects.h
@@ -399,6 +399,11 @@ const u8 gItemEffect_LeppaBerry[7] = {
     [6] = 10, // Amount of PP to recover
 };
 
+const u8 gItemEffect_HopoBerry[7] = {
+    [4] = ITEM4_HEAL_PP_ONE | ITEM4_HEAL_PP,
+    [6] = 10, // Amount of PP to recover
+};
+
 const u8 gItemEffect_OranBerry[7] = {
     [4] = ITEM4_HEAL_HP,
     [6] = 10, // Amount of HP to recover


### PR DESCRIPTION
## Summary
- add item constants for the unused Hopo Berry and the Legend Plate
- create basic item data and effects

## Testing
- `make -j4 test` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6877048f08908323ab310474ab5c1d8b