### PR TITLE
Handle partial wild encounter JSON

### DIFF
--- a/tools/wild_encounters/wild_encounters_to_header.py
+++ b/tools/wild_encounters/wild_encounters_to_header.py
@@ -140,7 +140,12 @@ def ImportWildEncounterFile():
     tabStr = "    "
 
     wFile = open("src/data/wild_encounters.json")
-    wData = json.load(wFile)
+    try:
+        wData = json.load(wFile)
+    except json.JSONDecodeError:
+        wFile.seek(0)
+        text = wFile.read()
+        wData, _ = json.JSONDecoder().raw_decode(text)
 
     encounterTotalCount = []
     encounterCount = []


### PR DESCRIPTION
## Summary
- robustly read `src/data/wild_encounters.json` when trailing data exists

## Testing
- `python3 -m json.tool src/data/wild_encounters.json` *(fails: Extra data)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9da109483239b3f1a5b55799632