### PR TITLE
Fix layout reference for Brendan house

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/map.json
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/map.json
@@ -1,7 +1,7 @@
 {
   "id": "MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_1F",
   "name": "LittlerootTown_BrendansHouse_1F",
-  "layout": "LAYOUT_LITTLEROOT_TOWN_BRENDANS_HOUSE_1F",
+  "layout": "LAYOUT_LITTLEROOT_TOWN_MAYS_HOUSE_1F",
   "music": "MUS_LITTLEROOT",
   "region_map_section": "MAPSEC_LITTLEROOT_TOWN",
   "requires_flash": false,


### PR DESCRIPTION
## Summary
- fix Brendan's House map layout reference

## Testing
- `make -j2` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791d4281e883239f613d047f20ed51