### PR TITLE
Fix missing map group entries causing build errors

### DIFF
--- a/data/maps/map_groups.json
+++ b/data/maps/map_groups.json
@@ -158,6 +158,8 @@
     "Underwater_Route125"
   ],
   "gMapGroup_IndoorLittleroot": [
+    "LittlerootTown_BrendansHouse_1F",
+    "LittlerootTown_BrendansHouse_2F",
     "LittlerootTown_PlayersHouse_1F",
     "LittlerootTown_PlayersHouse_2F",
     "LittlerootTown_MaysHouse_1F",


### PR DESCRIPTION
## Summary
- add Brendan's house maps to `gMapGroup_IndoorLittleroot`

These maps were missing from `data/maps/map_groups.json`. Without them, the build fails when assembling `scripts.inc` that reference `MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_2F`.

## Testing
- `make generated` *(fails: `arm-none-eabi-gcc` and `mapjson` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c23e3d5748323957374cd32612cf9