### PR TITLE
Fix script commands for rival graphics

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1128,11 +1128,25 @@
 	@ Checks if at least one Pokemon in the player's party knows the specified field move and if the field move is unlocked. If so, VAR_RESULT is set to the
 	@ (zero-indexed) slot number of the first Pokemon that knows the move. If not, VAR_RESULT is set to PARTY_SIZE.
 	@ VAR_0x8004 is also set to this Pokemon's species.
-	.macro checkfieldmove fieldMove:req, checkUnlocked=FALSE
-	.byte SCR_OP_CHECKFIELDMOVE
-	.byte \fieldMove
-	.byte \checkUnlocked
-	.endm
+        .macro checkfieldmove fieldMove:req, checkUnlocked=FALSE
+        .byte SCR_OP_CHECKFIELDMOVE
+        .byte \fieldMove
+        .byte \checkUnlocked
+        .endm
+
+        @ Checks if at least one Pokemon in the player's party knows the
+        @ specified move. If so, VAR_RESULT is set to the (zero-indexed)
+        @ party slot of the first Pokemon that knows the move, otherwise it is
+        @ set to PARTY_SIZE. VAR_0x8004 is also set to this Pokemon's species.
+        .macro checkpartymove move:req
+        .byte SCR_OP_CHECKPARTYMOVE
+        .2byte \move
+        .endm
+
+        @ Checks the player's region. Stores the result in VAR_RESULT.
+        .macro checkplayerregion
+        .byte SCR_OP_CHECKPLAYERREGION
+        .endm
 
 	@ Converts STR_VAR_1, STR_VAR_2, or STR_VAR_3 to its corresponding index into sScriptStringVars (0, 1, or 2).
 	@ If given anything else it will output it directly.

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -60,6 +60,7 @@
 #include "constants/trainers.h"
 #include "constants/tv.h"
 #include "constants/union_room.h"
+#include "constants/regions.h"
 #include "constants/vars.h"
 #include "constants/weather.h"
 #include "constants/quests.h"

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -256,8 +256,10 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_DYNMULTIPUSH                  ScrCmd_dynmultipush,                requests_effects=1  @ 0xe4
     script_cmd_table_entry SCR_OP_QUESTMENU                     ScrCmd_questmenu,                   requests_effects=1  @ 0xe5
     script_cmd_table_entry SCR_OP_RETURNQUESTSTATE              ScrCmd_returnqueststate,            requests_effects=1  @ 0xe6
-    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7	
-		.if ALLOCATE_SCRIPT_CMD_TABLE
+    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7
+        script_cmd_table_entry SCR_OP_CHECKPLAYERREGION             ScrCmd_checkplayerregion,          requests_effects=1  @ 0xe8
+        script_cmd_table_entry SCR_OP_CHECKPARTYMOVE                ScrCmd_checkpartymove,             requests_effects=1  @ 0xe9
+                .if ALLOCATE_SCRIPT_CMD_TABLE
 gScriptCmdTableEnd::
         .4byte ScrCmd_nop
         .endif

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -15,6 +15,7 @@
 #include "field_door.h"
 #include "field_effect.h"
 #include "field_move.h"
+#include "regions.h"
 #include "event_object_lock.h"
 #include "event_object_movement.h"
 #include "event_scripts.h"
@@ -2696,6 +2697,37 @@ bool8 ScrCmd_checkplayergender(struct ScriptContext *ctx)
     Script_RequestEffects(SCREFF_V1);
 
     gSpecialVar_Result = gSaveBlock2Ptr->playerGender;
+    return FALSE;
+}
+
+bool8 ScrCmd_checkplayerregion(struct ScriptContext *ctx)
+{
+    Script_RequestEffects(SCREFF_V1);
+
+    gSpecialVar_Result = GetCurrentRegion();
+    return FALSE;
+}
+
+bool8 ScrCmd_checkpartymove(struct ScriptContext *ctx)
+{
+    u16 move = ScriptReadHalfword(ctx);
+
+    Script_RequestEffects(SCREFF_V1);
+
+    gSpecialVar_Result = PARTY_SIZE;
+    for (u32 i = 0; i < PARTY_SIZE; i++)
+    {
+        u16 species = GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, NULL);
+        if (!species)
+            break;
+        if (!GetMonData(&gPlayerParty[i], MON_DATA_IS_EGG) && MonKnowsMove(&gPlayerParty[i], move))
+        {
+            gSpecialVar_Result = i;
+            gSpecialVar_0x8004 = species;
+            break;
+        }
+    }
+
     return FALSE;
 }
 


### PR DESCRIPTION
## Summary
- implement `checkpartymove` and `checkplayerregion` script commands
- expose new macros for event scripts
- include region constants when building event scripts

## Testing
- `make tools` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c237a1b2c83239cb9c01b539a6df9