### PR TITLE
Fix trainer battle macro parameters

### DIFF
--- a/data/maps/BattleFrontier_BattlePyramidFloor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidFloor/scripts.inc
@@ -105,10 +105,10 @@ BattlePyramid_WarpToTop::
 
 @ TRAINER_PHILLIP is used as a placeholder
 BattlePyramid_TrainerBattle::
-	trainerbattle TRAINER_BATTLE_PYRAMID, TRAINER_PHILLIP, 0, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText
-	pyramid_showhint
-	waitmessage
-	waitbuttonpress
+        trainerbattle TRAINER_BATTLE_PYRAMID, LOCALID_NONE, TRAINER_PHILLIP, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE, FALSE, FALSE
+        pyramid_showhint
+        waitmessage
+        waitbuttonpress
 	closemessage
 	releaseall
 	end

--- a/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
@@ -337,12 +337,12 @@ MossdeepCity_SpaceCenter_2F_EventScript_StevenFacePlayerWest::
 	return
 
 MossdeepCity_SpaceCenter_2F_EventScript_MaxieTrainer::
-	trainerbattle TRAINER_BATTLE_SET_TRAINER_A, TRAINER_MAXIE_MOSSDEEP, 0, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand
-	end
+        trainerbattle TRAINER_BATTLE_SET_TRAINER_A, LOCALID_NONE, TRAINER_MAXIE_MOSSDEEP, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE, FALSE, FALSE
+        end
 
 MossdeepCity_SpaceCenter_2F_EventScript_TabithaTrainer::
-	trainerbattle TRAINER_BATTLE_SET_TRAINER_B, TRAINER_TABITHA_MOSSDEEP, 0, MossdeepCity_SpaceCenter_Text_TabithaDefeat, MossdeepCity_SpaceCenter_Text_TabithaDefeat
-	end
+        trainerbattle TRAINER_BATTLE_SET_TRAINER_B, LOCALID_NONE, TRAINER_TABITHA_MOSSDEEP, MossdeepCity_SpaceCenter_Text_TabithaDefeat, MossdeepCity_SpaceCenter_Text_TabithaDefeat, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE, FALSE, FALSE
+        end
 
 MossdeepCity_SpaceCenter_2F_EventScript_RivalRayquazaCall::
 	lockall

--- a/data/scripts/trainer_hill.inc
+++ b/data/scripts/trainer_hill.inc
@@ -60,9 +60,9 @@ TrainerHill_1F_Movement_SetInvisible::
 
 @ TRAINER_PHILLIP is an actual Trainer on the SS Tidal, but is used as a placeholder here
 TrainerHill_EventScript_TrainerBattle::
-	trainerbattle TRAINER_BATTLE_HILL, TRAINER_PHILLIP, 0, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText
-	trainerhill_postbattletext
-	waitmessage
-	waitbuttonpress
+        trainerbattle TRAINER_BATTLE_HILL, LOCALID_NONE, TRAINER_PHILLIP, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE, FALSE, FALSE
+        trainerhill_postbattletext
+        waitmessage
+        waitbuttonpress
 	closemessage
 	end


### PR DESCRIPTION
## Summary
- update outdated trainerbattle calls for new macro definition

## Testing
- `make tools` *(fails: arm-none-eabi-gcc not found)*
- `make check` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c23d57c14832383e39cecb77789e5