### PR TITLE
Add checkplayerregion script command

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1396,9 +1396,14 @@
 	.endm
 
 	@ Checks the player's gender. Stores the result (MALE (0) or FEMALE (1)) in VAR_RESULT.
-	.macro checkplayergender
-	.byte SCR_OP_CHECKPLAYERGENDER
-	.endm
+        .macro checkplayergender
+        .byte SCR_OP_CHECKPLAYERGENDER
+        .endm
+
+        @ Checks the player's region. Stores the result (REGION_* constant) in VAR_RESULT.
+        .macro checkplayerregion
+        .byte SCR_OP_CHECKPLAYERREGION
+        .endm
 
 	@ Plays the cry of the given species. Mode is any CRY_MODE_* constant.
 	@ You can use waitmoncry to block script execution until the cry finishes.

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -256,8 +256,9 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_DYNMULTIPUSH                  ScrCmd_dynmultipush,                requests_effects=1  @ 0xe4
     script_cmd_table_entry SCR_OP_QUESTMENU                     ScrCmd_questmenu,                   requests_effects=1  @ 0xe5
     script_cmd_table_entry SCR_OP_RETURNQUESTSTATE              ScrCmd_returnqueststate,            requests_effects=1  @ 0xe6
-    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7	
-		.if ALLOCATE_SCRIPT_CMD_TABLE
+    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7
+    script_cmd_table_entry SCR_OP_CHECKPLAYERREGION           ScrCmd_checkplayerregion,        requests_effects=1  @ 0xe8
+                .if ALLOCATE_SCRIPT_CMD_TABLE
 gScriptCmdTableEnd::
         .4byte ScrCmd_nop
         .endif

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -58,6 +58,7 @@
 #include "window.h"
 #include "list_menu.h"
 #include "malloc.h"
+#include "regions.h"
 #include "quests.h"
 #include "constants/quest_menu.h"
 #include "constants/quests.h"
@@ -2696,6 +2697,14 @@ bool8 ScrCmd_checkplayergender(struct ScriptContext *ctx)
     Script_RequestEffects(SCREFF_V1);
 
     gSpecialVar_Result = gSaveBlock2Ptr->playerGender;
+    return FALSE;
+}
+
+bool8 ScrCmd_checkplayerregion(struct ScriptContext *ctx)
+{
+    Script_RequestEffects(SCREFF_V1);
+
+    gSpecialVar_Result = GetCurrentRegion();
     return FALSE;
 }
 


### PR DESCRIPTION
## Summary
- allow scripts to check the player's region
- expose new opcode in event macros
- hook the script command into the table and engine

## Testing
- `make -j2` *(fails: Missing parameters in various assembler macros)*

------
https://chatgpt.com/codex/tasks/task_e_687c2334c0c08323bccaadd232370178