### PR TITLE
Fix duplicate checkplayerregion macro

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1143,10 +1143,6 @@
         .2byte \move
         .endm
 
-        @ Checks the player's region. Stores the result in VAR_RESULT.
-        .macro checkplayerregion
-        .byte SCR_OP_CHECKPLAYERREGION
-        .endm
 
 	@ Converts STR_VAR_1, STR_VAR_2, or STR_VAR_3 to its corresponding index into sScriptStringVars (0, 1, or 2).
 	@ If given anything else it will output it directly.


### PR DESCRIPTION
## Summary
- remove duplicate definition of `checkplayerregion` in `event.inc`

## Testing
- `make -j5` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687c290e4ee483239948d5297e37f1a1