### PR TITLE
Fix InsideOfTruck script region constants

### DIFF
--- a/include/constants/regions.h
+++ b/include/constants/regions.h
@@ -18,4 +18,16 @@ enum Region
     REGIONS_COUNT,
 };
 
+// Convenience macros for script usage
+#define KANTO  REGION_KANTO
+#define JOHTO  REGION_JOHTO
+#define HOENN  REGION_HOENN
+#define SINNOH REGION_SINNOH
+#define UNOVA  REGION_UNOVA
+#define KALOS  REGION_KALOS
+#define ALOLA  REGION_ALOLA
+#define GALAR  REGION_GALAR
+#define HISUI  REGION_HISUI
+#define PALDEA REGION_PALDEA
+
 #endif  // GUARD_CONSTANTS_REGIONS_H


### PR DESCRIPTION
## Summary
- define region constants like `KANTO` and `JOHTO` for script assembly

## Testing
- `make -C tools/scaninc`
- `make` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c2cc8b5ac8323ba7d1bb412da3e3e