### PR TITLE
Fix multi battle script assembly errors

### DIFF
--- a/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
@@ -246,30 +246,23 @@ MossdeepCity_SpaceCenter_2F_EventScript_ReadyForBattlePrompt::
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_ChoosePartyForMultiBattle::
-	applymovement VAR_LAST_TALKED, Common_Movement_WalkInPlaceFasterDown
-	waitmovement 0
-	special SavePlayerParty
-	fadescreen FADE_TO_BLACK
-	special ChooseHalfPartyForBattle
-	waitstate
-	goto_if_ne VAR_RESULT, 0, MossdeepCity_SpaceCenter_2F_EventScript_DoStevenMultiBattle
-	special LoadPlayerParty
-	goto MossdeepCity_SpaceCenter_2F_EventScript_ReadyForBattlePrompt
+        applymovement VAR_LAST_TALKED, Common_Movement_WalkInPlaceFasterDown
+        waitmovement 0
+        special SavePlayerParty
+        fadescreen FADE_TO_BLACK
+        special ChooseHalfPartyForBattle
+        waitstate
+        goto_if_ne VAR_RESULT, 0, MossdeepCity_SpaceCenter_2F_EventScript_DoStevenMultiBattle
+        special LoadPlayerParty
+        goto MossdeepCity_SpaceCenter_2F_EventScript_ReadyForBattlePrompt
 
 MossdeepCity_SpaceCenter_2F_EventScript_DoStevenMultiBattle::
-	special ReducePlayerPartyToSelectedMons
-	frontier_set FRONTIER_DATA_SELECTED_MON_ORDER
-	setvar VAR_0x8004, SPECIAL_BATTLE_STEVEN
-	setvar VAR_0x8005, 0
-	special DoSpecialTrainerBattle
-	waitstate
-	frontier_saveparty
-	special LoadPlayerParty
-	switch VAR_RESULT
-	case 1, MossdeepCity_SpaceCenter_2F_EventScript_DefeatedMaxieTabitha
-	fadescreen FADE_TO_BLACK
-	special SetCB2WhiteOut
-	waitstate
+        multi_fixed_2_vs_2 TRAINER_MAXIE_MOSSDEEP, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, TRAINER_TABITHA_MOSSDEEP, MossdeepCity_SpaceCenter_Text_TabithaDefeat, PARTNER_STEVEN
+        switch VAR_RESULT
+        case 1, MossdeepCity_SpaceCenter_2F_EventScript_DefeatedMaxieTabitha
+        fadescreen FADE_TO_BLACK
+        special SetCB2WhiteOut
+        waitstate
 
 MossdeepCity_SpaceCenter_2F_EventScript_DefeatedMaxieTabitha::
 	msgbox MossdeepCity_SpaceCenter_2F_Text_MaxieWeFailedIsAquaAlsoMisguided, MSGBOX_DEFAULT
@@ -336,13 +329,6 @@ MossdeepCity_SpaceCenter_2F_EventScript_StevenFacePlayerWest::
 	turnobject LOCALID_STEVEN, DIR_EAST
 	return
 
-MossdeepCity_SpaceCenter_2F_EventScript_MaxieTrainer::
-        trainerbattle TRAINER_BATTLE_SET_TRAINER_A, LOCALID_NONE, TRAINER_MAXIE_MOSSDEEP, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, MossdeepCity_SpaceCenter_2F_Text_JustWantToExpandLand, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE, FALSE, FALSE
-        end
-
-MossdeepCity_SpaceCenter_2F_EventScript_TabithaTrainer::
-        trainerbattle TRAINER_BATTLE_SET_TRAINER_B, LOCALID_NONE, TRAINER_TABITHA_MOSSDEEP, MossdeepCity_SpaceCenter_Text_TabithaDefeat, MossdeepCity_SpaceCenter_Text_TabithaDefeat, NULL, LOCALID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, TRUE, FALSE, FALSE
-        end
 
 MossdeepCity_SpaceCenter_2F_EventScript_RivalRayquazaCall::
 	lockall


### PR DESCRIPTION
## Summary
- update the Space Center 2F battle scripts to use expansion macros
- remove unused trainer battle scripts

## Testing
- `make -j2` *(fails: non-constant expressions in other scripts)*

------
https://chatgpt.com/codex/tasks/task_e_687c2cbdc1dc8323bb1ea1d3910f5801