### PR TITLE
Improve build docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,10 @@ Follow these steps to build `pokeemerald-expansion`.
     ```console
     make
     ```
+    > **Note**: Do **not** run `arm-none-eabi-as` directly on the assembly files.
+    > The build system relies on the C preprocessor to define constants used by
+    > the assembly macros. Skipping `make` will cause errors such as "non-constant
+    > expression in `.if` statement".
 5. If everything worked correctly, something very similar to this should be seen.
 
     ```console

--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ To import Kanto and Johto content from the [cross](https://github.com/HeroSigma/
 ```
 
 This script clones the cross repository and copies Kanto and Johto maps, tilesets, scripts, trainer graphics, and trainer data into this project. Review the copied files and merge them as needed.
+
+## Building the Project
+To compile the ROM, run `make` from the repository root. The Makefile handles
+all preprocessing steps before assembly. Invoking `arm-none-eabi-as` directly on
+the source files will fail because the necessary constants are defined during
+the preprocessing stage.


### PR DESCRIPTION
## Summary
- note that `.s` files require the makefile's preprocessing step
- mention make in README and INSTALL docs

## Testing
- `make -n check` *(fails: missing cross-compiler initially)*
- `make -j2 check` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687c2cd723388323a7063edfde61c6b5