### PR TITLE
clarify assembler warning

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,13 @@ Follow these steps to build `pokeemerald-expansion`.
     ```console
     make
     ```
+    > **Note**: Always build through `make`. The Makefile preprocesses each `.s`
+    > file before assembling. Running `arm-none-eabi-as` yourself skips this step
+    > and leads to errors like:
+    >
+    > ```
+    > non-constant expression in `.if` statement
+    > ```
 5. If everything worked correctly, something very similar to this should be seen.
 
     ```console

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ To import Kanto and Johto content from the [cross](https://github.com/HeroSigma/
 ```
 
 This script clones the cross repository and copies Kanto and Johto maps, tilesets, scripts, trainer graphics, and trainer data into this project. Review the copied files and merge them as needed.
+
+## Building the Project
+To compile the ROM, run `make` from the repository root. The Makefile runs the
+C preprocessor on every assembly file before invoking the assembler. Skipping
+this step and calling `arm-none-eabi-as` yourself will leave macros without the
+constants they need, resulting in errors such as:
+
+```
+non-constant expression in `.if` statement
+```


### PR DESCRIPTION
## Summary
- refine README build instructions to mention the preprocessor step
- update INSTALL notes about `.if` errors when calling the assembler directly

## Testing
- `make -n check | head -n 20`
- `make -j2 check` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687c2cd723388323a7063edfde61c6b5