### PR TITLE
Fix duplicate map compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,9 @@ ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
 # get all the data/*.s files EXCEPT the ones with specific rules
-REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
+REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s $(DATA_ASM_SUBDIR)/*.cross.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 
-DATA_ASM_SRCS := $(wildcard $(DATA_ASM_SUBDIR)/*.s)
+DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/*.cross.s,$(wildcard $(DATA_ASM_SUBDIR)/*.s))
 DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DATA_ASM_SRCS))
 
 SONG_SRCS := $(wildcard $(SONG_SUBDIR)/*.s)


### PR DESCRIPTION
## Summary
- avoid compiling `*.cross.s` map sources

## Testing
- `make check -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3edaaa388323902c3554486141ce