### PR TITLE
Fix duplicate link errors from cross map sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,10 @@ ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
 # get all the data/*.s files EXCEPT the ones with specific rules
-REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
+REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s $(DATA_ASM_SUBDIR)/maps.cross.s $(DATA_ASM_SUBDIR)/map_events.cross.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 
-DATA_ASM_SRCS := $(wildcard $(DATA_ASM_SUBDIR)/*.s)
+# Exclude temporary cross-import files from being built by default
+DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.cross.s $(DATA_ASM_SUBDIR)/map_events.cross.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DATA_ASM_SRCS))
 
 SONG_SRCS := $(wildcard $(SONG_SUBDIR)/*.s)


### PR DESCRIPTION
## Summary
- prevent `maps.cross.s` and `map_events.cross.s` from building

## Testing
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_687c3ef055f08323b3502696e86ff32f