### PR TITLE
Fix duplicate map linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,9 @@ ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
 # get all the data/*.s files EXCEPT the ones with specific rules
-REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
+REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/maps.cross.s $(DATA_ASM_SUBDIR)/map_events.s $(DATA_ASM_SUBDIR)/map_events.cross.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 
-DATA_ASM_SRCS := $(wildcard $(DATA_ASM_SUBDIR)/*.s)
+DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.cross.s $(DATA_ASM_SUBDIR)/map_events.cross.s,$(wildcard $(DATA_ASM_SUBDIR)/*.s))
 DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DATA_ASM_SRCS))
 
 SONG_SRCS := $(wildcard $(SONG_SUBDIR)/*.s)


### PR DESCRIPTION
## Summary
- exclude `maps.cross.s` and `map_events.cross.s` from build

## Testing
- `make -pn | head` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c3effa534832390a4e8f2f32de5ab