### PR TITLE
Fix multiple map layout definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,15 @@ ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
 # get all the data/*.s files EXCEPT the ones with specific rules
-REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 
-DATA_ASM_SRCS := $(wildcard $(DATA_ASM_SUBDIR)/*.s)
+# Exclude integration dumps (e.g. *.cross.s) from normal build rules
+REGULAR_DATA_ASM_SRCS := $(filter-out \
+    $(DATA_ASM_SUBDIR)/maps.s \
+    $(DATA_ASM_SUBDIR)/map_events.s \
+    $(DATA_ASM_SUBDIR)/*.cross.s, \
+    $(wildcard $(DATA_ASM_SUBDIR)/*.s))
+
+DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/*.cross.s,$(wildcard $(DATA_ASM_SUBDIR)/*.s))
 DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DATA_ASM_SRCS))
 
 SONG_SRCS := $(wildcard $(SONG_SUBDIR)/*.s)


### PR DESCRIPTION
## Summary
- filter out `*.cross.s` map assembly sources from the Makefile

This prevents map data duplicated from the `cross` integration from being
assembled and linked, fixing the `arm-none-eabi-ld` errors about multiple
definitions.

## Testing
- `make -n` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3f200d5083238ab6766e053a5e86