### PR TITLE
Fix build errors for missing scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
 # get all the data/*.s files EXCEPT the ones with specific rules
-REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
+REGULAR_DATA_ASM_SRCS := $(filter-out $(DATA_ASM_SUBDIR)/maps.s $(DATA_ASM_SUBDIR)/map_events.s $(DATA_ASM_SUBDIR)/maps.cross.s $(DATA_ASM_SUBDIR)/map_events.cross.s, $(wildcard $(DATA_ASM_SUBDIR)/*.s))
 
 DATA_ASM_SRCS := $(wildcard $(DATA_ASM_SUBDIR)/*.s)
 DATA_ASM_OBJS := $(patsubst $(DATA_ASM_SUBDIR)/%.s,$(DATA_ASM_BUILDDIR)/%.o,$(DATA_ASM_SRCS))

--- a/data/scripts/field_move_scripts.inc
+++ b/data/scripts/field_move_scripts.inc
@@ -306,8 +306,29 @@ Text_WantToSurface:
 	.string "Would you like to use DIVE?$"
 
 EventScript_FailSweetScent::
-	msgbox Text_FailSweetScent, MSGBOX_SIGN
-	end
+        msgbox Text_FailSweetScent, MSGBOX_SIGN
+        end
 
 Text_FailSweetScent:
-	.string "Looks like there's nothing here…$"
+        .string "Looks like there's nothing here…$"
+
+EventScript_UseCutGrass::
+        lockall
+        dofieldeffect FLDEFF_USE_CUT_ON_GRASS
+        waitstate
+        releaseall
+        end
+
+EventScript_UseDefog::
+        lockall
+        dofieldeffect FLDEFF_DEFOG
+        waitstate
+        releaseall
+        end
+
+EventScript_UseDig::
+        lockall
+        dofieldeffect FLDEFF_USE_DIG
+        waitstate
+        releaseall
+        end

--- a/data/scripts/pc.inc
+++ b/data/scripts/pc.inc
@@ -58,9 +58,17 @@ EventScript_TurnOffPC::
 	end
 
 EventScript_AccessHallOfFame::
-	goto_if_unset FLAG_SYS_GAME_CLEAR, EventScript_TurnOffPC
-	playse SE_PC_LOGIN
-	special AccessHallOfFamePC
-	waitstate
-	goto EventScript_AccessPC
-	end
+        goto_if_unset FLAG_SYS_GAME_CLEAR, EventScript_TurnOffPC
+        playse SE_PC_LOGIN
+        special AccessHallOfFamePC
+        waitstate
+        goto EventScript_AccessPC
+        end
+
+EventScript_AccessPokemonBoxLink::
+        lockall
+        playse SE_PC_LOGIN
+        special ShowPokemonStorageSystemPC
+        waitstate
+        releaseall
+        end


### PR DESCRIPTION
## Summary
- avoid compiling cross map data
- add missing field move scripts for Defog, Dig, and cutting grass
- add script for the Pokémon Box Link

## Testing
- `make build/modern/data/event_scripts.o`
- `make build/modern/data/field_effect_scripts.o`
- `make build/modern/data/maps.o` *(fails: Failed to find matching layout)*

------
https://chatgpt.com/codex/tasks/task_e_687c42b6bcf08323a6ea2fba89a731e8