### PR TITLE
Restore follower movement scripts

### DIFF
--- a/data/scripts/movement.inc
+++ b/data/scripts/movement.inc
@@ -1,3 +1,6 @@
+@ Starting from here, these movements are considered
+@ 'safe' (won't put follower into a Pokeball)
+Common_Movement_FollowerSafeStart::
 Common_Movement_QuestionMark:
 	emote_question_mark
 	step_end
@@ -40,19 +43,19 @@ Common_Movement_WalkInPlaceFasterDown:
 	walk_in_place_faster_down
 	step_end
 
-Common_Movement_FaceRight:
+Common_Movement_FaceRight::
 	face_right
 	step_end
 
-Common_Movement_FaceLeft:
+Common_Movement_FaceLeft::
 	face_left
 	step_end
 
-Common_Movement_FaceDown:
+Common_Movement_FaceDown::
 	face_down
 	step_end
 
-Common_Movement_FaceUp:
+Common_Movement_FaceUp::
 	face_up
 	step_end
 
@@ -66,6 +69,10 @@ Common_Movement_WalkInPlaceLeft:
 
 Common_Movement_WalkInPlaceRight:
 	walk_in_place_right
+	step_end
+
+@ End of follower-safe movements
+Common_Movement_FollowerSafeEnd::
 	step_end
 
 Common_Movement_WalkUp6:
@@ -89,7 +96,7 @@ Common_Movement_Delay32:
 	delay_16
 	step_end
 
-Common_Movement_WalkUp:
+Common_Movement_WalkUp::
 	walk_up
 	step_end
 
@@ -98,3 +105,64 @@ Common_Movement_WalkUp2::
 	walk_up
 	walk_up
 	step_end
+
+@ Follower NPC
+Common_Movement_WalkUpSlow::
+    walk_slow_up
+    step_end
+
+Common_Movement_WalkDownSlow::
+    walk_slow_down
+    step_end
+
+Common_Movement_WalkRightSlow::
+    walk_slow_right
+    step_end
+
+Common_Movement_WalkLeftSlow::
+    walk_slow_left
+    step_end
+
+Common_Movement_WalkDown::
+    walk_down
+    step_end
+
+Common_Movement_WalkRight::
+    walk_right
+    step_end
+
+Common_Movement_WalkLeft::
+    walk_left
+    step_end
+
+Common_Movement_WalkUpFast::
+    walk_fast_up
+    step_end
+
+Common_Movement_WalkDownFast::
+    walk_fast_down
+    step_end
+
+Common_Movement_WalkRightFast::
+    walk_fast_right
+    step_end
+
+Common_Movement_WalkLeftFast::
+    walk_fast_left
+    step_end
+
+Common_Movement_WalkUpFaster::
+    walk_faster_up
+    step_end
+
+Common_Movement_WalkDownFaster::
+    walk_faster_down
+    step_end
+
+Common_Movement_WalkRightFaster::
+    walk_faster_right
+    step_end
+
+Common_Movement_WalkLeftFaster::
+    walk_faster_left
+    step_end


### PR DESCRIPTION
## Summary
- restore missing follower movement macros in `movement.inc`

## Testing
- `make -j2 tools`
- `make -j2` *(fails: libpng warnings but build proceeds)*

------
https://chatgpt.com/codex/tasks/task_e_687c42da679483238223da647bb22895