### PR TITLE
Add missing constants for Johto intro

### DIFF
--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -252,11 +252,13 @@
 #define OBJ_EVENT_GFX_POKE_BALL                  239
 #define OBJ_EVENT_GFX_OW_MON                     240
 #define OBJ_EVENT_GFX_LIGHT_SPRITE               241
+#define OBJ_EVENT_GFX_GRACE                      242
+#define OBJ_EVENT_GFX_PROF_ELM                   243
 
 // NOTE: The maximum amount of object events has been expanded from 255 to 65535.
 // Since dynamic graphics ids still require at least 16 free values, the actual limit
 // is 65519, but even considering follower Pokémon, this should be more than enough :)
-#define NUM_OBJ_EVENT_GFX                        242
+#define NUM_OBJ_EVENT_GFX                        244
 
 
 // These are dynamic object gfx ids.

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -731,13 +731,13 @@
 #define FLAG_UNUSED_0x2AD  0x2AD // Unused Flag
 #define FLAG_UNUSED_0x2AE  0x2AE // Unused Flag
 #define FLAG_UNUSED_0x2AF  0x2AF // Unused Flag
-#define FLAG_UNUSED_0x2B0  0x2B0 // Unused Flag
-#define FLAG_UNUSED_0x2B1  0x2B1 // Unused Flag
-#define FLAG_UNUSED_0x2B2  0x2B2 // Unused Flag
-#define FLAG_UNUSED_0x2B3  0x2B3 // Unused Flag
-#define FLAG_UNUSED_0x2B4  0x2B4 // Unused Flag
-#define FLAG_UNUSED_0x2B5  0x2B5 // Unused Flag
-#define FLAG_UNUSED_0x2B6  0x2B6 // Unused Flag
+#define FLAG_HIDE_PLAYERS_HOUSE_MOM            0x2B0
+#define FLAG_HIDE_PLAYERS_HOUSE_VIGOROTH_1     0x2B1
+#define FLAG_HIDE_PLAYERS_HOUSE_VIGOROTH_2     0x2B2
+#define FLAG_HIDE_ELMS_LAB_PROF_ELM            0x2B3
+#define FLAG_HIDE_ELMS_LAB_RIVAL               0x2B4
+#define FLAG_HIDE_ROUTE_29_ELM                 0x2B5
+#define FLAG_HIDE_ROUTE_29_RIVAL               0x2B6
 #define FLAG_UNUSED_0x2B7  0x2B7 // Unused Flag
 #define FLAG_UNUSED_0x2B8  0x2B8 // Unused Flag
 #define FLAG_UNUSED_0x2B9  0x2B9 // Unused Flag

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -148,7 +148,7 @@
 #define VAR_ROUTE133_STATE                               0x4080 // Unused Var
 #define VAR_ROUTE134_STATE                               0x4081 // Unused Var
 #define VAR_LITTLEROOT_HOUSES_STATE_MAY                  0x4082
-#define VAR_UNUSED_0x4083                                0x4083 // Unused Var
+#define VAR_INTRO_BATTLE_STATE                           0x4083
 #define VAR_BIRCH_LAB_STATE                              0x4084
 #define VAR_PETALBURG_GYM_STATE                          0x4085 // 0-1: Wally tutorial, 2-6: 0-4 badges, 7: Defeated Norman, 8: Rematch Norman
 #define VAR_CONTEST_HALL_STATE                           0x4086
@@ -162,8 +162,9 @@
 #define VAR_BOARD_BRINEY_BOAT_STATE                      0x408E
 #define VAR_DEVON_CORP_3F_STATE                          0x408F
 #define VAR_BRINEY_HOUSE_STATE                           0x4090
-#define VAR_UNUSED_0x4091                                0x4091 // Unused Var
+#define VAR_ELM_LAB_STATE                                0x4091
 #define VAR_LITTLEROOT_INTRO_STATE                       0x4092
+#define VAR_INTRO_STATE                                  VAR_LITTLEROOT_INTRO_STATE
 #define VAR_MAUVILLE_GYM_STATE                           0x4093
 #define VAR_LILYCOVE_MUSEUM_2F_STATE                     0x4094
 #define VAR_LILYCOVE_FAN_CLUB_STATE                      0x4095
@@ -172,7 +173,7 @@
 #define VAR_PETALBURG_WOODS_STATE                        0x4098
 #define VAR_LILYCOVE_CONTEST_LOBBY_STATE                 0x4099
 #define VAR_RUSTURF_TUNNEL_STATE                         0x409A
-#define VAR_UNUSED_0x409B                                0x409B // Unused Var
+#define VAR_OAK_LAB_STATE                                0x409B
 #define VAR_ELITE_4_STATE                                0x409C
 #define VAR_UNUSED_0x409D                                0x409D // Unused Var
 #define VAR_MOSSDEEP_SPACE_CENTER_STAIR_GUARD_STATE      0x409E


### PR DESCRIPTION
## Summary
- define new object graphics for Grace and Professor Elm
- allocate flags for Johto intro events
- add variables for Johto intro scripts and alias VAR_INTRO_STATE

## Testing
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_687c439da6d88323a067f49749d1dc5c