### PR TITLE
Fix missing tileset data when importing Cross

### DIFF
--- a/dev_scripts/integrate_cross.sh
+++ b/dev_scripts/integrate_cross.sh
@@ -55,6 +55,9 @@ copy_dir "$TMP_DIR/data/layouts" "data/layouts"
 copy_dir "$TMP_DIR/data/scripts" "data/scripts"
 copy_dir "$TMP_DIR/data/tilesets" "data/tilesets"
 
+# Copy tileset include files used by the build system
+copy_dir "$TMP_DIR/src/data/tilesets" "src/data/tilesets"
+
 # Copy trainer graphics and data
 copy_dir "$TMP_DIR/graphics/trainers" "graphics/trainers"
 copy_file "$TMP_DIR/src/data/trainers.h" "src/data/trainers.h.cross"


### PR DESCRIPTION
## Summary
- update `integrate_cross.sh` to also copy tileset header files from the Cross repo

## Testing
- `git clean -fdx`
- `./dev_scripts/integrate_cross.sh` *(succeeds)*
- `make -j$(nproc)` *(fails: `data/maps/LavaridgeTown_Gym_1F/scripts.inc:107: Error: Missing value for required parameter`)*

------
https://chatgpt.com/codex/tasks/task_e_687c4432270c83239772cb44db789286