### PR TITLE
Add starter randomization setting

### DIFF
--- a/include/config/general.h
+++ b/include/config/general.h
@@ -74,6 +74,7 @@
 #define AUTO_SCROLL_TEXT             TRUE   // If TRUE, text will automatically scroll to the next line after NUM_FRAMES_AUTO_SCROLL_DELAY. Players can still press A_BUTTON or B_BUTTON to scroll on their own.
 #define NUM_FRAMES_AUTO_SCROLL_DELAY 49
 #define PHONEMES_SHARED              FALSE   // If TRUE, bard phonemes all reference the same sound (sound/direct_sound_samples/phonemes/shared.bin) to save ROM space.
+#define RANDOMIZE_STARTERS           FALSE   // If TRUE, the three starter Pokémon will be randomized on each new save file.
 
 // Measurement system constants to be used for UNITS
 #define UNITS_IMPERIAL               0       // Inches, feet, pounds

--- a/include/global.h
+++ b/include/global.h
@@ -584,7 +584,13 @@ struct SaveBlock2
              //u16 padding1:4;
              //u16 padding2;
     /*0x18*/ struct Pokedex pokedex;
-    /*0x90*/ u8 filler_90[0x8];
+    /*0x90*/
+#if RANDOMIZE_STARTERS
+    u16 starterSpecies[3];
+    u16 filler_90;
+#else
+    u8 filler_90[0x8];
+#endif
     /*0x98*/ struct Time localTimeOffset;
     /*0xA0*/ struct Time lastBerryTreeUpdate;
     /*0xA8*/ u32 gcnLinkFlags; // Read by Pokémon Colosseum/XD

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -94,6 +94,28 @@ static void InitPlayerTrainerId(void)
     SetTrainerId(trainerId, gSaveBlock2Ptr->playerTrainerId);
 }
 
+#if RANDOMIZE_STARTERS
+static void InitRandomStarters(void)
+{
+    int i, j;
+    u16 species;
+
+    for (i = 0; i < 3; i++)
+    {
+        do {
+            species = (Random() % (NUM_SPECIES - 1)) + 1;
+            for (j = 0; j < i; j++)
+            {
+                if (gSaveBlock2Ptr->starterSpecies[j] == species)
+                    break;
+            }
+        } while (j != i);
+
+        gSaveBlock2Ptr->starterSpecies[i] = species;
+    }
+}
+#endif
+
 // L=A isnt set here for some reason.
 static void SetDefaultOptions(void)
 {
@@ -170,6 +192,9 @@ void NewGameInitData(void)
     gSaveBlock2Ptr->specialSaveWarpFlags = 0;
     gSaveBlock2Ptr->gcnLinkFlags = 0;
     InitPlayerTrainerId();
+#if RANDOMIZE_STARTERS
+    InitRandomStarters();
+#endif
     PlayTimeCounter_Reset();
     ClearPokedexFlags();
     InitEventData();

--- a/src/starter_choose.c
+++ b/src/starter_choose.c
@@ -350,9 +350,15 @@ static const struct SpriteTemplate sSpriteTemplate_StarterCircle =
 // .text
 u16 GetStarterPokemon(u16 chosenStarterId)
 {
+#if RANDOMIZE_STARTERS
+    if (chosenStarterId >= 3)
+        chosenStarterId = 0;
+    return gSaveBlock2Ptr->starterSpecies[chosenStarterId];
+#else
     if (chosenStarterId > STARTER_MON_COUNT)
         chosenStarterId = 0;
     return sStarterMon[chosenStarterId];
+#endif
 }
 
 static void VblankCB_StarterChoose(void)


### PR DESCRIPTION
## Summary
- add `RANDOMIZE_STARTERS` option
- store starter species in `SaveBlock2`
- initialize random starters for each new save file
- use randomized starters during selection

## Testing
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_687cc53813788323be80c1e6bdf955dd