### PR TITLE
Remove duplicate flag and var definitions

### DIFF
--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -734,8 +734,8 @@
 #define FLAG_HIDE_PLAYERS_HOUSE_MOM            0x2B0
 #define FLAG_HIDE_PLAYERS_HOUSE_VIGOROTH_1     0x2B1
 #define FLAG_HIDE_PLAYERS_HOUSE_VIGOROTH_2     0x2B2
-#define FLAG_HIDE_ELMS_LAB_PROF_ELM            0x2B3
-#define FLAG_HIDE_ELMS_LAB_RIVAL               0x2B4
+#define FLAG_UNUSED_0x2B3  0x2B3 // Unused Flag
+#define FLAG_UNUSED_0x2B4  0x2B4 // Unused Flag
 #define FLAG_HIDE_ROUTE_29_ELM                 0x2B5
 #define FLAG_HIDE_ROUTE_29_RIVAL               0x2B6
 #define FLAG_UNUSED_0x2B7  0x2B7 // Unused Flag

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -148,7 +148,7 @@
 #define VAR_ROUTE133_STATE                               0x4080 // Unused Var
 #define VAR_ROUTE134_STATE                               0x4081 // Unused Var
 #define VAR_LITTLEROOT_HOUSES_STATE_MAY                  0x4082
-#define VAR_INTRO_BATTLE_STATE                           0x4083
+#define VAR_UNUSED_0x4083                                0x4083 // Unused Var
 #define VAR_BIRCH_LAB_STATE                              0x4084
 #define VAR_PETALBURG_GYM_STATE                          0x4085 // 0-1: Wally tutorial, 2-6: 0-4 badges, 7: Defeated Norman, 8: Rematch Norman
 #define VAR_CONTEST_HALL_STATE                           0x4086


### PR DESCRIPTION
## Summary
- resolve warnings from duplicate constants by ensuring unique definitions

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfce31f6c8323a22e6402a49e683c