### PR TITLE
Fix map events cross build dependency

### DIFF
--- a/map_data_rules.mk
+++ b/map_data_rules.mk
@@ -25,6 +25,9 @@ $(DATA_ASM_BUILDDIR)/maps.o: $(DATA_ASM_SUBDIR)/maps.s $(LAYOUTS_DIR)/layouts.in
 $(DATA_ASM_BUILDDIR)/map_events.o: $(DATA_ASM_SUBDIR)/map_events.s $(MAPS_DIR)/events.inc $(MAP_EVENTS)
 	$(PREPROC) $< charmap.txt | $(CPP) -I include - | $(PREPROC) -ie $< charmap.txt | $(AS) $(ASFLAGS) -o $@
 
+$(DATA_ASM_BUILDDIR)/map_events.cross.o: $(DATA_ASM_SUBDIR)/map_events.cross.s $(MAPS_DIR)/events.inc $(MAP_EVENTS)
+	$(PREPROC) $< charmap.txt | $(CPP) -I include - | $(PREPROC) -ie $< charmap.txt | $(AS) $(ASFLAGS) -o $@
+
 $(MAPS_OUTDIR)/%/header.inc $(MAPS_OUTDIR)/%/events.inc $(MAPS_OUTDIR)/%/connections.inc: $(MAPS_DIR)/%/map.json
 	$(MAPJSON) map emerald $< $(LAYOUTS_DIR)/layouts.json $(@D)
 


### PR DESCRIPTION
## Summary
- add dependency rule for `map_events.cross.o`

## Testing
- `make -n generated`
- `make -j1 build/modern/data/map_events.cross.o`

------
https://chatgpt.com/codex/tasks/task_e_687d0103ae408323bc709a9cf819644a