### PR TITLE
Fix battle tent script directives

### DIFF
--- a/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
@@ -1,6 +1,6 @@
-.set LOCALID_PLAYER, 1
-.set LOCALID_ATTENDANT, 2
-.set LOCALID_OPPONENT, 3
+.equ LOCALID_PLAYER, 1
+.equ LOCALID_ATTENDANT, 2
+.equ LOCALID_OPPONENT, 3
 
 FallarborTown_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FallarborTown_BattleTentBattleRoom_OnTransition

--- a/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
@@ -1,5 +1,5 @@
-.set LOCALID_OPPONENT, 2
-.set LOCALID_PLAYER, 3
+.equ LOCALID_OPPONENT, 2
+.equ LOCALID_PLAYER, 3
 
 SlateportCity_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SlateportCity_BattleTentBattleRoom_OnTransition

--- a/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
@@ -1,6 +1,6 @@
-.set LOCALID_PLAYER, 1
-.set LOCALID_OPPONENT, 2
-.set LOCALID_ATTENDANT, 3
+.equ LOCALID_PLAYER, 1
+.equ LOCALID_OPPONENT, 2
+.equ LOCALID_ATTENDANT, 3
 
 VerdanturfTown_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, VerdanturfTown_BattleTentBattleRoom_OnTransition


### PR DESCRIPTION
## Summary
- use `.equ` instead of `.set` for local IDs in battle tent battle room scripts

## Testing
- `make test` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d2fd3abe88323bbf73cfeef445b4d