### PR TITLE
Fix trainerbattle parameters in Trainer Hill script

### DIFF
--- a/data/scripts/trainer_hill.inc
+++ b/data/scripts/trainer_hill.inc
@@ -60,9 +60,9 @@ TrainerHill_1F_Movement_SetInvisible::
 
 @ TRAINER_PHILLIP is an actual Trainer on the SS Tidal, but is used as a placeholder here
 TrainerHill_EventScript_TrainerBattle::
-	trainerbattle TRAINER_BATTLE_HILL, TRAINER_PHILLIP, 0, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText
-	trainerhill_postbattletext
-	waitmessage
-	waitbuttonpress
-	closemessage
-	end
+        trainerbattle TRAINER_BATTLE_HILL, OBJ_ID_NONE, TRAINER_PHILLIP, BattleFacility_TrainerBattle_PlaceholderText, BattleFacility_TrainerBattle_PlaceholderText, NULL, OBJ_ID_NONE, TRAINER_NONE, NULL, NULL, NULL, NULL, NULL, FALSE, FALSE, FALSE, FALSE
+        trainerhill_postbattletext
+        waitmessage
+        waitbuttonpress
+        closemessage
+        end


### PR DESCRIPTION
## Summary
- correct the `trainerbattle` macro call in `trainer_hill.inc`

## Testing
- `make -j2` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687d3019d2a88323ba65a4b2ecd1552f