### PR TITLE
Fix map constants causing build errors

### DIFF
--- a/data/maps/BirthIsland_Exterior/scripts.inc
+++ b/data/maps/BirthIsland_Exterior/scripts.inc
@@ -72,8 +72,8 @@ BirthIsland_Exterior_EventScript_Complete::
 BirthIsland_Exterior_EventScript_Deoxys::
 	waitse
 	setfieldeffectargument 0, LOCALID_BIRTH_ISLAND_EXTERIOR_ROCK
-	setfieldeffectargument 1, MAP_NUM(BIRTH_ISLAND_EXTERIOR)
-	setfieldeffectargument 2, MAP_GROUP(BIRTH_ISLAND_EXTERIOR)
+    setfieldeffectargument 1, MAP_NUM(MAP_BIRTH_ISLAND_EXTERIOR)
+    setfieldeffectargument 2, MAP_GROUP(MAP_BIRTH_ISLAND_EXTERIOR)
 	dofieldeffect FLDEFF_DESTROY_DEOXYS_ROCK
 	playbgm MUS_RG_ENCOUNTER_DEOXYS, FALSE
 	waitfieldeffect FLDEFF_DESTROY_DEOXYS_ROCK

--- a/data/maps/map_groups.json
+++ b/data/maps/map_groups.json
@@ -160,6 +160,8 @@
   "gMapGroup_IndoorLittleroot": [
     "LittlerootTown_PlayersHouse_1F",
     "LittlerootTown_PlayersHouse_2F",
+    "LittlerootTown_BrendansHouse_1F",
+    "LittlerootTown_BrendansHouse_2F",
     "LittlerootTown_MaysHouse_1F",
     "LittlerootTown_MaysHouse_2F",
     "LittlerootTown_ProfessorBirchsLab"


### PR DESCRIPTION
## Summary
- add Brendans house maps to `map_groups.json`
- correct Birth Island map constant usage

## Testing
- `make build/modern/data/event_scripts.o` *(fails: Missing parameters in unrelated scripts)*

------
https://chatgpt.com/codex/tasks/task_e_687d302086cc8323a31c2da89438f112