### PR TITLE
Fix missing tileset animation callbacks

### DIFF
--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -858,7 +858,7 @@ const struct Tileset gTileset_KantoGeneral =
     .palettes = gTilesetPalettes_KantoGeneral,
     .metatiles = gMetatiles_KantoGeneral,
     .metatileAttributes = gMetatileAttributes_KantoGeneral,
-    .callback = InitTilesetAnim_KantoGeneral,
+    .callback = InitTilesetAnim_General,
 };
 
 const struct Tileset gTileset_JohtoGeneral =
@@ -869,7 +869,7 @@ const struct Tileset gTileset_JohtoGeneral =
     .palettes = gTilesetPalettes_JohtoGeneral,
     .metatiles = gMetatiles_JohtoGeneral,
     .metatileAttributes = gMetatileAttributes_JohtoGeneral,
-    .callback = InitTilesetAnim_JohtoGeneral,
+    .callback = InitTilesetAnim_General,
 };
 
 const struct Tileset gTileset_KantoBuilding =


### PR DESCRIPTION
## Summary
- use the existing `InitTilesetAnim_General` for Kanto and Johto general tilesets

## Testing
- `make -j4 modern` *(fails: non-constant expression in move_tutors.inc)*

------
https://chatgpt.com/codex/tasks/task_e_687d3ce23bd08323a3b7095bb538aaae