### PR TITLE
Fix map section IDs in region_map_sections.json

### DIFF
--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -1704,7 +1704,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_NEW_BARK_TOWN",
+      "id": "MAPSEC_NEW_BARK_TOWN",
       "name": "NEW BARK TOWN",
       "x": 0,
       "y": 0,
@@ -1712,7 +1712,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_CHERRYGROVE_CITY",
+      "id": "MAPSEC_CHERRYGROVE_CITY",
       "name": "CHERRYGROVE CITY",
       "x": 0,
       "y": 0,
@@ -1720,7 +1720,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_VIOLET_CITY",
+      "id": "MAPSEC_VIOLET_CITY",
       "name": "VIOLET CITY",
       "x": 0,
       "y": 0,
@@ -1728,7 +1728,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_AZALEA_TOWN",
+      "id": "MAPSEC_AZALEA_TOWN",
       "name": "AZALEA TOWN",
       "x": 0,
       "y": 0,
@@ -1736,7 +1736,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_GOLDENROD_CITY",
+      "id": "MAPSEC_GOLDENROD_CITY",
       "name": "GOLDENROD CITY",
       "x": 0,
       "y": 0,
@@ -1744,7 +1744,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ECRUTEAK_CITY",
+      "id": "MAPSEC_ECRUTEAK_CITY",
       "name": "ECRUTEAK CITY",
       "x": 0,
       "y": 0,
@@ -1752,7 +1752,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_OLIVINE_CITY",
+      "id": "MAPSEC_OLIVINE_CITY",
       "name": "OLIVINE CITY",
       "x": 0,
       "y": 0,
@@ -1760,7 +1760,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_CIANWOOD_CITY",
+      "id": "MAPSEC_CIANWOOD_CITY",
       "name": "CIANWOOD CITY",
       "x": 0,
       "y": 0,
@@ -1768,7 +1768,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_MAHOGANY_TOWN",
+      "id": "MAPSEC_MAHOGANY_TOWN",
       "name": "MAHOGANY TOWN",
       "x": 0,
       "y": 0,
@@ -1776,7 +1776,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_BLACKTHORN_CITY",
+      "id": "MAPSEC_BLACKTHORN_CITY",
       "name": "BLACKTHORN CITY",
       "x": 0,
       "y": 0,
@@ -1784,7 +1784,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_26",
+      "id": "MAPSEC_ROUTE_26",
       "name": "ROUTE 26",
       "x": 0,
       "y": 0,
@@ -1792,7 +1792,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_27",
+      "id": "MAPSEC_ROUTE_27",
       "name": "ROUTE 27",
       "x": 0,
       "y": 0,
@@ -1800,7 +1800,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_28",
+      "id": "MAPSEC_ROUTE_28",
       "name": "ROUTE 28",
       "x": 0,
       "y": 0,
@@ -1808,7 +1808,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_29",
+      "id": "MAPSEC_ROUTE_29",
       "name": "ROUTE 29",
       "x": 0,
       "y": 0,
@@ -1816,7 +1816,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_30",
+      "id": "MAPSEC_ROUTE_30",
       "name": "ROUTE 30",
       "x": 0,
       "y": 0,
@@ -1824,7 +1824,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_31",
+      "id": "MAPSEC_ROUTE_31",
       "name": "ROUTE 31",
       "x": 0,
       "y": 0,
@@ -1832,7 +1832,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_32",
+      "id": "MAPSEC_ROUTE_32",
       "name": "ROUTE 32",
       "x": 0,
       "y": 0,
@@ -1840,7 +1840,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_33",
+      "id": "MAPSEC_ROUTE_33",
       "name": "ROUTE 33",
       "x": 0,
       "y": 0,
@@ -1848,7 +1848,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_34",
+      "id": "MAPSEC_ROUTE_34",
       "name": "ROUTE 34",
       "x": 0,
       "y": 0,
@@ -1856,7 +1856,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_35",
+      "id": "MAPSEC_ROUTE_35",
       "name": "ROUTE 35",
       "x": 0,
       "y": 0,
@@ -1864,7 +1864,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_36",
+      "id": "MAPSEC_ROUTE_36",
       "name": "ROUTE 36",
       "x": 0,
       "y": 0,
@@ -1872,7 +1872,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_37",
+      "id": "MAPSEC_ROUTE_37",
       "name": "ROUTE 37",
       "x": 0,
       "y": 0,
@@ -1880,7 +1880,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_38",
+      "id": "MAPSEC_ROUTE_38",
       "name": "ROUTE 38",
       "x": 0,
       "y": 0,
@@ -1888,7 +1888,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_39",
+      "id": "MAPSEC_ROUTE_39",
       "name": "ROUTE 39",
       "x": 0,
       "y": 0,
@@ -1896,7 +1896,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_40",
+      "id": "MAPSEC_ROUTE_40",
       "name": "ROUTE 40",
       "x": 0,
       "y": 0,
@@ -1904,7 +1904,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_41",
+      "id": "MAPSEC_ROUTE_41",
       "name": "ROUTE 41",
       "x": 0,
       "y": 0,
@@ -1912,7 +1912,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_42",
+      "id": "MAPSEC_ROUTE_42",
       "name": "ROUTE 42",
       "x": 0,
       "y": 0,
@@ -1920,7 +1920,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_43",
+      "id": "MAPSEC_ROUTE_43",
       "name": "ROUTE 43",
       "x": 0,
       "y": 0,
@@ -1928,7 +1928,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_44",
+      "id": "MAPSEC_ROUTE_44",
       "name": "ROUTE 44",
       "x": 0,
       "y": 0,
@@ -1936,7 +1936,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_45",
+      "id": "MAPSEC_ROUTE_45",
       "name": "ROUTE 45",
       "x": 0,
       "y": 0,
@@ -1944,7 +1944,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ROUTE_46",
+      "id": "MAPSEC_ROUTE_46",
       "name": "ROUTE 46",
       "x": 0,
       "y": 0,
@@ -1952,7 +1952,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_RUINS_OF_ALPH",
+      "id": "MAPSEC_RUINS_OF_ALPH",
       "name": "RUINS OF ALPH",
       "x": 0,
       "y": 0,
@@ -1960,7 +1960,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_SLOWPOKE_WELL",
+      "id": "MAPSEC_SLOWPOKE_WELL",
       "name": "SLOWPOKE WELL",
       "x": 0,
       "y": 0,
@@ -1968,7 +1968,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_UNION_CAVE",
+      "id": "MAPSEC_UNION_CAVE",
       "name": "UNION CAVE",
       "x": 0,
       "y": 0,
@@ -1976,7 +1976,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ILEX_FOREST",
+      "id": "MAPSEC_ILEX_FOREST",
       "name": "ILEX FOREST",
       "x": 0,
       "y": 0,
@@ -1984,7 +1984,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_RADIO_TOWER",
+      "id": "MAPSEC_RADIO_TOWER",
       "name": "RADIO TOWER",
       "x": 0,
       "y": 0,
@@ -1992,7 +1992,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_NATIONAL_PARK",
+      "id": "MAPSEC_NATIONAL_PARK",
       "name": "NATIONAL PARK",
       "x": 0,
       "y": 0,
@@ -2000,7 +2000,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_TIN_TOWER",
+      "id": "MAPSEC_TIN_TOWER",
       "name": "TIN TOWER",
       "x": 0,
       "y": 0,
@@ -2008,7 +2008,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_BELL_TOWER",
+      "id": "MAPSEC_BELL_TOWER",
       "name": "BELL TOWER",
       "x": 0,
       "y": 0,
@@ -2016,7 +2016,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_BURNED_TOWER",
+      "id": "MAPSEC_BURNED_TOWER",
       "name": "BURNED TOWER",
       "x": 0,
       "y": 0,
@@ -2024,7 +2024,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_SPROUT_TOWER",
+      "id": "MAPSEC_SPROUT_TOWER",
       "name": "SPROUT TOWER",
       "x": 0,
       "y": 0,
@@ -2032,7 +2032,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_WHIRL_ISLANDS",
+      "id": "MAPSEC_WHIRL_ISLANDS",
       "name": "WHIRL ISLANDS",
       "x": 0,
       "y": 0,
@@ -2040,7 +2040,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_DARK_CAVE",
+      "id": "MAPSEC_DARK_CAVE",
       "name": "DARK CAVE",
       "x": 0,
       "y": 0,
@@ -2048,7 +2048,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_MT_MORTAR",
+      "id": "MAPSEC_MT_MORTAR",
       "name": "MT. MORTAR",
       "x": 0,
       "y": 0,
@@ -2056,7 +2056,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_LAKE_OF_RAGE",
+      "id": "MAPSEC_LAKE_OF_RAGE",
       "name": "LAKE OF RAGE",
       "x": 0,
       "y": 0,
@@ -2064,7 +2064,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_ICE_PATH",
+      "id": "MAPSEC_ICE_PATH",
       "name": "ICE PATH",
       "x": 0,
       "y": 0,
@@ -2072,7 +2072,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_DRAGONS_DEN",
+      "id": "MAPSEC_DRAGONS_DEN",
       "name": "DRAGON'S DEN",
       "x": 0,
       "y": 0,
@@ -2080,7 +2080,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_TOHJO_FALLS",
+      "id": "MAPSEC_TOHJO_FALLS",
       "name": "TOHJO FALLS",
       "x": 0,
       "y": 0,
@@ -2088,7 +2088,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_MT_SILVER",
+      "id": "MAPSEC_MT_SILVER",
       "name": "MT. SILVER",
       "x": 0,
       "y": 0,
@@ -2096,7 +2096,7 @@
       "height": 1
     },
     {
-      "map_section": "MAPSEC_DYNAMIC",
+      "id": "MAPSEC_DYNAMIC",
       "name": "",
       "x": 0,
       "y": 0,


### PR DESCRIPTION
## Summary
- correct `map_section` -> `id` fields in `region_map_sections.json`

## Testing
- `tools/jsonproc/jsonproc src/data/region_map/region_map_sections.json src/data/region_map/region_map_sections.json.txt /tmp/region_map_entries.h`
- `tools/jsonproc/jsonproc src/data/region_map/region_map_sections.json src/data/region_map/region_map_sections.constants.json.txt /tmp/region_map_sections.h`


------
https://chatgpt.com/codex/tasks/task_e_687efdb9991c8323b98b9875590f77ee