### PR TITLE
Fix compile errors with stub function and flag

### DIFF
--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -51,6 +51,7 @@
 #define B_FLAG_NO_WHITEOUT   0x25 // No Whiteout
 #define FLAG_UNUSED_0x026    0x26 // Unused Flag
 #define FLAG_UNUSED_0x027    0x27 // Unused Flag
+#define FLAG_INSTANT_EXP_BAR 0x28 // Instantly fill EXP bar during battles
 #define FLAG_UNUSED_0x029    0x29 // Unused Flag
 #define I_EXP_SHARE_FLAG     0x2A // EXP Share
 #define FLAG_HIDE_ZYGARDE    0x2B

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2067,6 +2067,11 @@ void UpdateHealthboxAttribute(u8 healthboxSpriteId, struct Pokemon *mon, u8 elem
 #define B_EXPBAR_PIXELS 64
 #define B_HEALTHBAR_PIXELS 48
 
+static inline u32 Rogue_GetBattleSpeedScale(bool8 useExpBar)
+{
+    (void)useExpBar;
+    return 1;
+}
 
 s32 MoveBattleBar(u8 battler, u8 healthboxSpriteId, u8 whichBar, u8 unused)
 {


### PR DESCRIPTION
## Summary
- add missing FLAG_INSTANT_EXP_BAR definition
- stub out Rogue_GetBattleSpeedScale so that `battle_interface` builds

## Testing
- `make -j1` *(fails: `constants/expansion.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f07eb1a0c83238a10263bf821739e