### PR TITLE
Fix missing expansion header

### DIFF
--- a/include/constants/expansion.h
+++ b/include/constants/expansion.h
@@ -1,0 +1,13 @@
+#ifndef GUARD_CONSTANTS_EXPANSION_H
+#define GUARD_CONSTANTS_EXPANSION_H
+
+// Last version: 1.12.1
+#define EXPANSION_VERSION_MAJOR 1
+#define EXPANSION_VERSION_MINOR 12
+#define EXPANSION_VERSION_PATCH 2
+
+// FALSE if this this version of Expansion is not a tagged commit, i.e.
+// it contains unreleased changes.
+#define EXPANSION_TAGGED_RELEASE FALSE
+
+#endif


### PR DESCRIPTION
## Summary
- add `include/constants/expansion.h` from pokeemerald-expansion

## Testing
- `make -j$(nproc) modern` *(fails: MB_FALL_WARP undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_687f0b44625c83238032d6be8ec3799a