### PR TITLE
Fix missing flag for Wattson rematch

### DIFF
--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -484,7 +484,7 @@
 #define FLAG_ENABLE_TATE_AND_LIZA_MATCH_CALL 0x1D8
 #define FLAG_ENABLE_JUAN_MATCH_CALL          0x1D9
 
-#define FLAG_UNUSED_0x1DA                    0x1DA // Unused Flag
+#define FLAG_WATTSON_REMATCH_AVAILABLE       0x1DA
 
 #define FLAG_SHOWN_MYSTIC_TICKET             0x1DB
 #define FLAG_DEFEATED_HO_OH                  0x1DC


### PR DESCRIPTION
## Summary
- add `FLAG_WATTSON_REMATCH_AVAILABLE` in the flag list

## Testing
- `make -j$(nproc)` *(fails: Failed to open palette files)*

------
https://chatgpt.com/codex/tasks/task_e_687f711a80148323824755a71be3aa0a