### PR TITLE
Add fruit tree BG event support

### DIFF
--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -107,14 +107,19 @@
 	.endm
 
 	@ Defines a background hidden item event for map data
-	.macro bg_hidden_item_event x:req, y:req, elevation:req, item:req, flag:req
-	bg_event \x, \y, \elevation, BG_EVENT_HIDDEN_ITEM, \item, ((\flag) - FLAG_HIDDEN_ITEMS_START)
-	.endm
+        .macro bg_hidden_item_event x:req, y:req, elevation:req, item:req, flag:req
+        bg_event \x, \y, \elevation, BG_EVENT_HIDDEN_ITEM, \item, ((\flag) - FLAG_HIDDEN_ITEMS_START)
+        .endm
 
-	@ Defines a background secret base event for map data
-	.macro bg_secret_base_event x:req, y:req, elevation:req, secret_base_id:req
-	bg_event \x, \y, \elevation, BG_EVENT_SECRET_BASE, \secret_base_id
-	.endm
+        @ Defines a background secret base event for map data
+        .macro bg_secret_base_event x:req, y:req, elevation:req, secret_base_id:req
+        bg_event \x, \y, \elevation, BG_EVENT_SECRET_BASE, \secret_base_id
+        .endm
+
+        @ Defines a background fruit tree event for map data
+        .macro bg_fruit_tree_event x:req, y:req, elevation:req, fruit_tree_id:req
+        bg_event \x, \y, \elevation, BG_EVENT_FRUIT_TREE, \fruit_tree_id
+        .endm
 
 	@ Defines the table of event data for a map. Mirrors the struct layout of MapEvents in include/global.fieldmap.h
 	.macro map_events npcs:req, warps:req, traps:req, signs:req

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -336,8 +336,15 @@ string generate_map_events_text(Json map_data) {
                      << json_to_string(bg_event, "y") << ", "
                      << json_to_string(bg_event, "elevation") << ", "
                      << json_to_string(bg_event, "secret_base_id") << "\n";
+            }
+            else if (type == "fruit_tree") {
+                text << "\tbg_fruit_tree_event "
+                     << json_to_string(bg_event, "x") << ", "
+                     << json_to_string(bg_event, "y") << ", "
+                     << json_to_string(bg_event, "elevation") << ", "
+                     << json_to_string(bg_event, "fruit_tree_id") << "\n";
             } else {
-                FATAL_ERROR("Unknown bg event type '%s'. Expected 'sign', 'hidden_item', or 'secret_base'.\n", type.c_str());
+                FATAL_ERROR("Unknown bg event type '%s'. Expected 'sign', 'hidden_item', 'secret_base', or 'fruit_tree'.\n", type.c_str());
             }
         }
         text << "\n";


### PR DESCRIPTION
## Summary
- add macro `bg_fruit_tree_event`
- update `mapjson` tool to handle the new `fruit_tree` background event type

## Testing
- `make -C tools/mapjson`
- `./tools/mapjson/mapjson map emerald data/maps/Route29/map.json data/layouts/layouts.json data/maps/Route29`
- `make check` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687f869a8a108323b43161dc79d08c3e