### PR TITLE
Fix unused function warning

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -214,7 +214,6 @@ static void LoadMainMenuWindowFrameTiles(u8, u16);
 static void DrawMainMenuWindowBorder(const struct WindowTemplate *, u16);
 static void Task_HighlightSelectedMainMenuItem(u8);
 static void Task_NewGameBirchSpeech_WaitToShowGenderMenu(u8);
-static void Task_NewGameBirchSpeech_WaitToShowAppearanceMenu(u8);
 static void Task_NewGameBirchSpeech_ChooseGender(u8);
 static void Task_NewGameBirchSpeech_ChooseAppearance(u8);
 static void NewGameBirchSpeech_ShowGenderMenu(void);
@@ -1616,15 +1615,6 @@ static void Task_NewGameBirchSpeech_SlideInNewGenderSprite(u8 taskId)
             gSprites[spriteId].oam.objMode = ST_OAM_OBJ_NORMAL;
             gTasks[taskId].func = Task_NewGameBirchSpeech_ChooseGender;
         }
-    }
-}
-
-static void Task_NewGameBirchSpeech_WaitToShowAppearanceMenu(u8 taskId)
-{
-    if (!RunTextPrintersAndIsPrinter0Active())
-    {
-        NewGameBirchSpeech_ShowAppearanceMenu();
-        gTasks[taskId].func = Task_NewGameBirchSpeech_ChooseAppearance;
     }
 }
 


### PR DESCRIPTION
## Summary
- clean up `main_menu.c` by removing an unused task

## Testing
- `make -j2` *(fails: Failed to open JASC-PAL file "graphics/battle_environment/water/palette.pal" for reading.)*


------
https://chatgpt.com/codex/tasks/task_e_687f969596b88323890c5ae6b05d95fc