### PR TITLE
Include missing map groups header

### DIFF
--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -23,6 +23,7 @@
 #include "pokedex_area_region_map.h"
 #include "wild_encounter.h"
 #include "window.h"
+#include "constants/map_groups.h"
 #include "constants/region_map_sections.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"


### PR DESCRIPTION
## Summary
- include `constants/map_groups.h` in `pokedex_area_screen.c`

## Testing
- `make -j$(nproc)` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa35cb27c83238266d370b0525700