### PR TITLE
Fix warnings for region selection callbacks

### DIFF
--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -725,6 +725,10 @@ struct
     [MENU_CATALOG_MOWER]   = {COMPOUND_STRING("Lawn mower"),      CursorCb_CatalogMower},
     [MENU_CHANGE_FORM]     = {COMPOUND_STRING("Change form"),     CursorCb_ChangeForm},
     [MENU_CHANGE_ABILITY]  = {COMPOUND_STRING("Change Ability"),  CursorCb_ChangeAbility},
+    [MENU_KANTO]           = {gText_Kanto,                       CursorCb_Kanto},
+    [MENU_JOHTO]           = {gText_Johto,                       CursorCb_Johto},
+    [MENU_HOENN]           = {gText_Hoenn,                       CursorCb_Hoenn},
+    [MENU_SEVII]           = {gText_Sevii_Menu,                  CursorCb_Sevii},
 };
 
 static const u8 sPartyMenuAction_SummarySwitchCancel[] = {MENU_SUMMARY, MENU_SWITCH, MENU_CANCEL1};


### PR DESCRIPTION
## Summary
- include new map region menu options in cursor options
- ensures region menu callbacks (Kanto/Johto/Hoenn/Sevii) are referenced so they aren't optimized away

## Testing
- `make -j5`

------
https://chatgpt.com/codex/tasks/task_e_687fa534ec0c832382db713922737e8d