### PR TITLE
Fix missing DAYS_PER_WEEK constant

### DIFF
--- a/include/constants/siirtc.h
+++ b/include/constants/siirtc.h
@@ -10,6 +10,7 @@
 #define HOURS_PER_DAY       24
 #define MINUTES_PER_HOUR    60
 #define SECONDS_PER_MINUTE  60
+#define DAYS_PER_WEEK       WEEKDAY_COUNT
 
 enum Weekday
 {


### PR DESCRIPTION
## Summary
- define `DAYS_PER_WEEK` in constants so rtc can build

## Testing
- `make -j2` *(fails: Failed to open graphics/battle_environment/water/palette.pal)*

------
https://chatgpt.com/codex/tasks/task_e_687fbc8603908323b4073c6856802861