### PR TITLE
Fix dynamic map section name

### DIFF
--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -698,6 +698,7 @@
     },
     {
       "id": "MAPSEC_DYNAMIC",
+      "name": "DYNAMIC",
       "x": 0,
       "y": 0,
       "width": 1,


### PR DESCRIPTION
## Summary
- give MAPSEC_DYNAMIC a name so region_map_entries.h defines `sMapName_DYNAMIC`

## Testing
- `make -j8` *(fails: Failed to open JASC-PAL file "graphics/battle_environment/water/palette.pal" for reading)*

------
https://chatgpt.com/codex/tasks/task_e_687fe41d46f08323a7510c7bdb0c0517