### PR TITLE
Fix event script assembler checks

### DIFF
--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -63,9 +63,21 @@
 #include "constants/vars.h"
 #include "constants/weather.h"
 #include "constants/quests.h"
-	.include "asm/macros.inc"
-	.include "asm/macros/event.inc"
-	.include "constants/constants.inc"
+        .include "asm/macros.inc"
+        .include "asm/macros/event.inc"
+        .include "constants/constants.inc"
+
+        @ Prevent macro substitution of variable constants
+        #undef VARS_START
+        #undef VARS_END
+        #undef SPECIAL_VARS_START
+        #undef SPECIAL_VARS_END
+
+        @ Definitions required by event script macros
+        .set VARS_START, 0x4000
+        .set VARS_END, 0x4107
+        .set SPECIAL_VARS_START, 0x8000
+        .set SPECIAL_VARS_END, 0x8016
 
 	.section script_data, "aw", %progbits
 


### PR DESCRIPTION
## Summary
- undefine macro constants so they can be redefined for asm
- set required VAR and special VAR ranges before scripts are assembled

## Testing
- `tools/preproc/preproc data/event_scripts.s charmap.txt | arm-none-eabi-cpp -I include - | tools/preproc/preproc -ie data/event_scripts.s charmap.txt | arm-none-eabi-as -mcpu=arm7tdmi -march=armv4t -meabi=5 --defsym MODERN=1 -o manual.o` *(fails: `map_event_ids.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688024506f1c8323ba7b91aa3814f4aa