### PR TITLE
Fix default macro parameter in event scripts

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -145,7 +145,7 @@
 	.endm
 
 	@ Changes the value of destination to value.
-	.macro setvar destination:req, value:req, warn=TRUE
+        .macro setvar destination:req, value:req, warn=1
 	.if \warn && ((\value >= VARS_START && \value <= VARS_END) || (\value >= SPECIAL_VARS_START && \value <= SPECIAL_VARS_END))
 	.warning "setvar with a value that might be a VAR_ constant; did you mean copyvar instead?"
 	.endif


### PR DESCRIPTION
## Summary
- fix `setvar` macro default value to avoid undefined constant issues

## Testing
- `make -j2` *(fails: Failed to open JASC-PAL file "graphics/battle_environment/water/palette.pal" for reading.)*

------
https://chatgpt.com/codex/tasks/task_e_68802c0d6c208323ae792d3633976964