### PR TITLE
Fix EverGrandeCity map merge conflict

### DIFF
--- a/data/maps/EverGrandeCity/map.json
+++ b/data/maps/EverGrandeCity/map.json
@@ -20,7 +20,6 @@
     }
   ],
   "object_events": [
-<<<<<<< HEAD
     {
       "local_id": "LOCALID_EVER_GRANDE_KELDEO",
       "graphics_id": "OBJ_EVENT_GFX_KELDEO",
@@ -35,9 +34,6 @@
       "script": "EverGrandeCity_Keldeo",
       "flag": "FLAG_HIDE_KELDEO"
     }
-=======
-
->>>>>>> ibs/master
   ],
   "warp_events": [
     {


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in `data/maps/EverGrandeCity/map.json`
- keep the Keldeo object event data

## Testing
- `tools/mapjson/mapjson groups emerald data/maps/map_groups.json data/maps include/constants`
- `make -j2` *(fails: 'gActiveBattler' undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6880516c49188323abf32d6798a1a11f