### PR TITLE
Fix compile error using removed gActiveBattler

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -402,17 +402,17 @@ static void HandleInputChooseAction(u32 battler)
             PlaySE(SE_SELECT);
 
             // Auto jump to run option
-            switch (gActionSelectionCursor[gActiveBattler])
+            switch (gActionSelectionCursor[battler])
             {
             case 3: // Bottom right
-                BtlController_EmitTwoReturnValues(BUFFER_B, B_ACTION_RUN, 0);
-                PlayerBufferExecCompleted();
+                BtlController_EmitTwoReturnValues(battler, B_COMM_TO_ENGINE, B_ACTION_RUN, 0);
+                PlayerBufferExecCompleted(battler);
                 break;
 
             default: // Bottom left
-                ActionSelectionDestroyCursorAt(gActionSelectionCursor[gActiveBattler]);
-                gActionSelectionCursor[gActiveBattler] = 3;
-                ActionSelectionCreateCursorAt(gActionSelectionCursor[gActiveBattler], 0);
+                ActionSelectionDestroyCursorAt(gActionSelectionCursor[battler]);
+                gActionSelectionCursor[battler] = 3;
+                ActionSelectionCreateCursorAt(gActionSelectionCursor[battler], 0);
                 break;
             }
         }


### PR DESCRIPTION
## Summary
- fix runtime reference to removed `gActiveBattler`

## Testing
- `make -j2` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805579601083238c7dc0d84a3d2380