### PR TITLE
Add stubs for SSTidal special functions

### DIFF
--- a/data/specials.inc
+++ b/data/specials.inc
@@ -515,11 +515,25 @@ gSpecials::
 	def_special IsTrainerRegistered
 	def_special ShouldDoBrailleRegicePuzzle
 	def_special EnableNationalPokedex
-	def_special ScriptMenu_CreateLilycoveSSTidalMultichoice
-	def_special GetLilycoveSSTidalSelection
-	def_special TurnOnTVScreen
-	def_special SetMewAboveGrass
-	def_special ShouldDistributeEonTicket
+        def_special ScriptMenu_CreateLilycoveSSTidalMultichoice
+        def_special GetLilycoveSSTidalSelection
+        def_special ScriptMenu_CreateSeviiSSTidalMultichoice
+        def_special GetSeviiSSTidalSelection
+        def_special ScriptMenu_CreateSevii2SSTidalMultichoice
+        def_special GetSevii2SSTidalSelection
+        def_special ScriptMenu_CreateSevii3SSTidalMultichoice
+        def_special GetSevii3SSTidalSelection
+        def_special ScriptMenu_CreateSevii6SSTidalMultichoice
+        def_special GetSevii6SSTidalSelection
+        def_special ScriptMenu_CreateSevii7SSTidalMultichoice
+        def_special GetSevii7SSTidalSelection
+        def_special ScriptMenu_CreateLilycoveSSTidalSeviiMultichoice
+        def_special GetLilycoveSSTidalSeviiSelection
+        def_special ScriptMenu_CreateVermilionSSTidalMultichoice
+        def_special GetVermilionSSTidalSelection
+        def_special TurnOnTVScreen
+        def_special SetMewAboveGrass
+        def_special ShouldDistributeEonTicket
 	def_special LinkRetireStatusWithBattleTowerPartner
 	def_special BattleTowerReconnectLink
 	def_special CallTrainerHillFunction

--- a/include/script_menu.h
+++ b/include/script_menu.h
@@ -46,5 +46,19 @@ int DisplayTextAndGetWidth(const u8 *str, int prevWidth);
 int ScriptMenu_AdjustLeftCoordFromWidth(int left, int width);
 bool16 ScriptMenu_CreatePCMultichoice(void);
 void ScriptMenu_DisplayPCStartupPrompt(void);
+bool8 ScriptMenu_CreateSeviiSSTidalMultichoice(void);
+void GetSeviiSSTidalSelection(void);
+bool8 ScriptMenu_CreateSevii2SSTidalMultichoice(void);
+void GetSevii2SSTidalSelection(void);
+bool8 ScriptMenu_CreateSevii3SSTidalMultichoice(void);
+void GetSevii3SSTidalSelection(void);
+bool8 ScriptMenu_CreateSevii6SSTidalMultichoice(void);
+void GetSevii6SSTidalSelection(void);
+bool8 ScriptMenu_CreateSevii7SSTidalMultichoice(void);
+void GetSevii7SSTidalSelection(void);
+bool8 ScriptMenu_CreateLilycoveSSTidalSeviiMultichoice(void);
+void GetLilycoveSSTidalSeviiSelection(void);
+bool8 ScriptMenu_CreateVermilionSSTidalMultichoice(void);
+void GetVermilionSSTidalSelection(void);
 
 #endif //GUARD_SCRIPT_MENU_H

--- a/src/ss_tidal_stub.c
+++ b/src/ss_tidal_stub.c
@@ -1,0 +1,74 @@
+#include "global.h"
+#include "script.h"
+#include "script_menu.h"
+
+bool8 ScriptMenu_CreateSeviiSSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetSeviiSSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateSevii2SSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetSevii2SSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateSevii3SSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetSevii3SSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateSevii6SSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetSevii6SSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateSevii7SSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetSevii7SSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateLilycoveSSTidalSeviiMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetLilycoveSSTidalSeviiSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+
+bool8 ScriptMenu_CreateVermilionSSTidalMultichoice(void)
+{
+    return FALSE;
+}
+
+void GetVermilionSSTidalSelection(void)
+{
+    gSpecialVar_Result = MULTI_B_PRESSED;
+}
+


### PR DESCRIPTION
## Summary
- add stub functions for missing Sevii SS Tidal menu routines
- export new functions in `script_menu.h`
- register new specials in `data/specials.inc`

## Testing
- `make -j2` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68817b4174fc8323b6a68b5e5ff35289