### PR TITLE
Fix seasons compile error

### DIFF
--- a/include/rtc.h
+++ b/include/rtc.h
@@ -45,5 +45,6 @@ u8 GetDay(void);
 enum Weekday GetDayOfWeek(void);
 enum TimeOfDay TryIncrementTimeOfDay(enum TimeOfDay timeOfDay);
 enum TimeOfDay TryDecrementTimeOfDay(enum TimeOfDay timeOfDay);
+u8 GetDaysInMonth(enum Month month);
 
 #endif // GUARD_RTC_UTIL_H

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -464,3 +464,14 @@ enum TimeOfDay TryDecrementTimeOfDay(enum TimeOfDay timeOfDay)
 {
     return timeOfDay == TIME_MORNING ? TIME_NIGHT : timeOfDay - 1;
 }
+
+u8 GetDaysInMonth(enum Month month)
+{
+    u16 year = GetFullYear();
+    u8 days = sNumDaysInMonths[month - 1];
+
+    if (month == MONTH_FEB && IsLeapYear(year))
+        days++;
+
+    return days;
+}


### PR DESCRIPTION
## Summary
- implement `GetDaysInMonth` in `rtc.c`
- expose `GetDaysInMonth` prototype in `rtc.h`

## Testing
- `make modern` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6881a3c122088323b438b83b544742a8