### PR TITLE
Fix missing brace in IsPlayerInFrontOfPC

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -1022,6 +1022,7 @@ static bool8 IsPlayerInFrontOfPC(void)
     tileInFront = MapGridGetMetatileIdAt(x, y);
 
     return IsBuildingPCTile(tileInFront) || IsPlayerHousePCTile(tileInFront);
+}
 
 void FieldShowRegionMapKanto(void)
 {


### PR DESCRIPTION
## Summary
- close `IsPlayerInFrontOfPC` with a proper brace

## Testing
- `make build/modern/src/field_specials.o` *(fails: `SCROLL_MULTI_SS_TIDAL_DESTINATION_SLATEPORT` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_6883bf26ffd88323975053176eb0e0f5