### PR TITLE
Fix unused variables

### DIFF
--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -1560,11 +1560,7 @@ static void CreateSeviiSSTidalMultichoice(void)
 {
     u8 selectionCount = 0;
     u8 count;
-    u32 pixelWidth;
-    u8 width;
-    u8 windowId;
     u8 i;
-    u32 j;
 
     for (i = 0; i < SSTIDAL_SELECTION_COUNT_S; i++)
     {


### PR DESCRIPTION
## Summary
- remove leftover unused variable declarations in `CreateSeviiSSTidalMultichoice`

## Testing
- `make check -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0a4c44883238de8cff58ec17485