### PR TITLE
Add Player House text definitions

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_1F/scripts.inc
@@ -184,9 +184,29 @@ LittlerootTown_PlayersHouse_1F_Movement_MomLeaveAndReturn:
 	step_end
 
 LittlerootTown_PlayersHouse_1F_Text_AlmostForgot:
-	.string "I almost forgot!\p"
-	.string "I spoke to a man named Professor Birch\n"
-	.string "here in Littleroot earlier today.\p" 
-	.string "He wants you to visit him in his lab,\n"
-	.string "please go and see him!\p"
-	.string "Bye {PLAYER}!$"
+        .string "I almost forgot!\p"
+        .string "I spoke to a man named Professor Birch\n"
+        .string "here in Littleroot earlier today.\p"
+        .string "He wants you to visit him in his lab,\n"
+        .string "please go and see him!\p"
+        .string "Bye {PLAYER}!$"
+
+PlayersHouse_1F_Text_PlayerReceivedPichu:
+        .string "{PLAYER} received PICHU!$"
+
+PlayersHouse_1F_Text_ThingsMovedOut:
+        .string "MOM: All of our things are finally\n"
+        .string "moved in.\p"
+        .string "It feels like everything is ready\n"
+        .string "for you to begin your journey.$"
+
+PlayersHouse_1F_Text_StartYourAdventure:
+        .string "MOM: It's time to start your very own\n"
+        .string "adventure, {PLAYER}!\p"
+        .string "Go make friends and discover new\n"
+        .string "POK\xe9MON!$"
+
+PlayersHouse_1F_Text_TakeCareOfHouse:
+        .string "MOM: Take care of the house while\n"
+        .string "I'm away, okay?\p"
+        .string "I'll be thinking of you!$"

--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -86,6 +86,13 @@ Common_Text_LookCloserAtMapSevii:
 	.string "SEVII ISLES map.$"
 
 PlayersHouse_2F_Text_ItsAGameCube:
-	.string "It's a Nintendo GameCube.\p"
-	.string "A Game Boy Advance is connected to\n"
-	.string "serve as the Controller.$"
+        .string "It's a Nintendo GameCube.\p"
+        .string "A Game Boy Advance is connected to\n"
+        .string "serve as the Controller.$"
+
+PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
+        .string "MOM: How do you like your room?\p"
+        .string "Everything's put away neatly.\n"
+        .string "They finished moving everything\n"
+        .string "in downstairs, too!\p"
+        .string "POK\xe9MON movers are so convenient!$"

--- a/data/maps/NewBarkTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/NewBarkTown_PlayersHouse_1F/scripts.inc
@@ -201,12 +201,32 @@ NewBarkTown_PlayersHouse_1F_Movement_MomLeave:
 	step_end
 
 NewBarkTown_PlayersHouse_1F_Text_AlmostForgot:
-	.string "I almost forgot!\p"
-	.string "I spoke to a man named Professor Elm\n"
-	.string "here in New Bark Town earlier today.\p" 
-	.string "He wants you to visit him in his lab,\n"
-	.string "please go and see him!\p"
-	.string "Bye {PLAYER}!$"
+        .string "I almost forgot!\p"
+        .string "I spoke to a man named Professor Elm\n"
+        .string "here in New Bark Town earlier today.\p"
+        .string "He wants you to visit him in his lab,\n"
+        .string "please go and see him!\p"
+        .string "Bye {PLAYER}!$"
+
+PlayersHouse_1F_Text_PlayerReceivedPichu:
+        .string "{PLAYER} received PICHU!$"
+
+PlayersHouse_1F_Text_ThingsMovedOut:
+        .string "MOM: All of our things are finally\n"
+        .string "moved in.\p"
+        .string "It feels like everything is ready\n"
+        .string "for you to begin your journey.$"
+
+PlayersHouse_1F_Text_StartYourAdventure:
+        .string "MOM: It's time to start your very own\n"
+        .string "adventure, {PLAYER}!\p"
+        .string "Go make friends and discover new\n"
+        .string "POK\xe9MON!$"
+
+PlayersHouse_1F_Text_TakeCareOfHouse:
+        .string "MOM: Take care of the house while\n"
+        .string "I'm away, okay?\p"
+        .string "I'll be thinking of you!$"
 
 NewBarkTown_PlayersHouse_1F_Text_MaybeDadWillBeOn:
 	.string "MOM: Look! It's Violet City Gym!\n"

--- a/data/maps/NewBarkTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/NewBarkTown_PlayersHouse_2F/scripts.inc
@@ -14,6 +14,13 @@ NewBarkTown_PlayersHouse_2F_OnWarp:
 	.2byte 0
 
 NewBarkTown_PlayersHouse_2F_EventScript_CheckInitDecor::
-	checkplayergender
-	goto_if_eq VAR_RESULT, MALE, SecretBase_EventScript_InitDecorations
-	end
+        checkplayergender
+        goto_if_eq VAR_RESULT, MALE, SecretBase_EventScript_InitDecorations
+        end
+
+PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
+        .string "MOM: How do you like your room?\p"
+        .string "Everything's put away neatly.\n"
+        .string "They finished moving everything\n"
+        .string "in downstairs, too!\p"
+        .string "POK\xe9MON movers are so convenient!$"

--- a/data/maps/PalletTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/PalletTown_PlayersHouse_1F/scripts.inc
@@ -177,9 +177,29 @@ PalletTown_PlayersHouse_1F_Movement_MomLeaveAndReturn:
 	step_end
 
 PalletTown_PlayersHouse_1F_Text_AlmostForgot:
-	.string "I almost forgot!\p"
-	.string "I spoke to a man named Professor Oak\n"
-	.string "here in Pallet Town earlier today.\p" 
-	.string "He wants you to visit him in his lab,\n"
-	.string "please go and see him!\p"
-	.string "Bye {PLAYER}!$"
+        .string "I almost forgot!\p"
+        .string "I spoke to a man named Professor Oak\n"
+        .string "here in Pallet Town earlier today.\p"
+        .string "He wants you to visit him in his lab,\n"
+        .string "please go and see him!\p"
+        .string "Bye {PLAYER}!$"
+
+PlayersHouse_1F_Text_PlayerReceivedPichu:
+        .string "{PLAYER} received PICHU!$"
+
+PlayersHouse_1F_Text_ThingsMovedOut:
+        .string "MOM: All of our things are finally\n"
+        .string "moved in.\p"
+        .string "It feels like everything is ready\n"
+        .string "for you to begin your journey.$"
+
+PlayersHouse_1F_Text_StartYourAdventure:
+        .string "MOM: It's time to start your very own\n"
+        .string "adventure, {PLAYER}!\p"
+        .string "Go make friends and discover new\n"
+        .string "POK\xe9MON!$"
+
+PlayersHouse_1F_Text_TakeCareOfHouse:
+        .string "MOM: Take care of the house while\n"
+        .string "I'm away, okay?\p"
+        .string "I'll be thinking of you!$"

--- a/data/maps/PalletTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/PalletTown_PlayersHouse_2F/scripts.inc
@@ -3,5 +3,12 @@ PalletTown_PlayersHouse_2F_MapScripts::
 	.byte 0
 
 PalletTown_PlayersHouse_2F_OnTransition:
-	call_if_eq VAR_INTRO_STATE, 4, PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet
-	end
+        call_if_eq VAR_INTRO_STATE, 4, PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet
+        end
+
+PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
+        .string "MOM: How do you like your room?\p"
+        .string "Everything's put away neatly.\n"
+        .string "They finished moving everything\n"
+        .string "in downstairs, too!\p"
+        .string "POK\xe9MON movers are so convenient!$"


### PR DESCRIPTION
## Summary
- define PlayerReceivedPichu and related dialogues
- add HowDoYouLikeYourRoom text for player's upstairs

## Testing
- `make -j$(nproc)` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883f10da0f8832396c619560e3c401b