### PR TITLE
Add missing braille text

### DIFF
--- a/data/text/braille.inc
+++ b/data/text/braille.inc
@@ -110,8 +110,92 @@ IslandCave_Braille_RunLapAroundWall:
 	.braille "ONE LAP.$"
 
 AncientTomb_Braille_ShineInTheMiddle:
-	brailleformat 3, 0, 25, 19, 6, 3
-	.braille "THOSE WHO\n"
-	.braille "INHERIT OUR\n"
-	.braille "WILL, SHINE\n"
-	.braille "IN THE MIDDLE.$"
+        brailleformat 3, 0, 25, 19, 6, 3
+        .braille "THOSE WHO\n"
+        .braille "INHERIT OUR\n"
+        .braille "WILL, SHINE\n"
+        .braille "IN THE MIDDLE.$"
+
+Braille_Text_Everything:
+        .braille "EVERYTHING$"
+
+Braille_Text_HasMeaning1:
+        .braille "HAS MEANING$"
+
+Braille_Text_Existence:
+        .braille "EXISTENCE$"
+
+Braille_Text_HasMeaning2:
+        .braille "HAS MEANING$"
+
+Braille_Text_BeingAlive:
+        .braille "BEING ALIVE$"
+
+Braille_Text_HasMeaning3:
+        .braille "HAS MEANING$"
+
+Braille_Text_HaveDreams:
+        .braille "HAVE DREAMS$"
+
+Braille_Text_UsePower:
+        .braille "USE POWER.$"
+
+Braille_Text_Up:
+        .braille "UP$"
+
+Braille_Text_Left:
+        .braille "LEFT$"
+
+Braille_Text_Right:
+        .braille "RIGHT$"
+
+Braille_Text_Down:
+        .braille "DOWN$"
+
+Braille_Text_LetTheTwo:
+        .braille "LET THE TWO$"
+
+Braille_Text_Glittering:
+        .braille "GLITTERING$"
+
+Braille_Text_Stones:
+        .braille "STONES$"
+
+Braille_Text_OneInRed:
+        .braille "ONE IN RED$"
+
+Braille_Text_OneInBlue:
+        .braille "ONE IN BLUE$"
+
+Braille_Text_ConnectThe:
+        .braille "CONNECT THE$"
+
+Braille_Text_Past:
+        .braille "PAST.$"
+
+Braille_Text_TwoFriends:
+        .braille "TWO FRIENDS$"
+
+Braille_Text_Sharing:
+        .braille "SHARING$"
+
+Braille_Text_PowerOpen:
+        .braille "POWER OPEN$"
+
+Braille_Text_AWindowTo:
+        .braille "A WINDOW TO$"
+
+Braille_Text_ANewWorld:
+        .braille "A NEW WORLD$"
+
+Braille_Text_ThatGlows:
+        .braille "THAT GLOWS.$"
+
+Braille_Text_TheNext:
+        .braille "THE NEXT$"
+
+Braille_Text_WorldWaits:
+        .braille "WORLD WAITS$"
+
+Braille_Text_ForYou:
+        .braille "FOR YOU.$"


### PR DESCRIPTION
## Summary
- define braille text strings needed by Dotted Hole and Ruby Path events
- strings are based on official FRLG wording

## Testing
- `make build/modern/data/event_scripts.o`

------
https://chatgpt.com/codex/tasks/task_e_6883f11360ac8323b961f402a945a32d