### PR TITLE
Add NPC sprite rules

### DIFF
--- a/graphics_file_rules.mk
+++ b/graphics_file_rules.mk
@@ -284,6 +284,9 @@ $(TITLESCREENGFXDIR)/emerald_version.8bpp: %.8bpp: %.png
 graphics/pokemon_jump/bg.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 63 -Wnum_tiles
 
+$(OBJEVENTGFXDIR)/palettes/prof_elm.gbapal: %.gbapal: %.pal
+	$(GFX) $< $@
+
 graphics/pokenav/region_map/map.8bpp: %.8bpp: %.png
 	$(GFX) $< $@ -num_tiles 233 -Wnum_tiles
 

--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -306,6 +306,18 @@ $(OBJEVENTGFXDIR)/people/picnicker.4bpp: %.4bpp: %.png
 $(OBJEVENTGFXDIR)/people/prof_birch.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
+$(OBJEVENTGFXDIR)/people/delia.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/grace.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/prof_elm.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
+$(OBJEVENTGFXDIR)/people/prof_oak.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -mwidth 2 -mheight 4
+
 $(OBJEVENTGFXDIR)/people/psychic_m.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 


### PR DESCRIPTION
## Summary
- add spritesheet conversion rules for delia, grace, prof_elm and prof_oak
- include prof_elm palette rule in graphics build

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688402f8a4f88323b25ba9b8211f9da4