### PR TITLE
Add wardrobe customization infrastructure

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1903,6 +1903,22 @@
     .2byte \childId
     .endm
 
+    .macro setwardrobe top:req, bottom:req, hair:req, hat:req
+    .byte SCR_OP_SETWARDROBE
+    .2byte \top
+    .2byte \bottom
+    .2byte \hair
+    .2byte \hat
+    .endm
+
+    .macro getwardrobe top:req, bottom:req, hair:req, hat:req
+    .byte SCR_OP_GETWARDROBE
+    .2byte \top
+    .2byte \bottom
+    .2byte \hair
+    .2byte \hat
+    .endm
+
     @ Check the quest state and return a number associated with quest state
     .macro returnqueststate questId:req
     .byte SCR_OP_RETURNQUESTSTATE

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -256,8 +256,10 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_DYNMULTIPUSH                  ScrCmd_dynmultipush,                requests_effects=1  @ 0xe4
     script_cmd_table_entry SCR_OP_QUESTMENU                     ScrCmd_questmenu,                   requests_effects=1  @ 0xe5
     script_cmd_table_entry SCR_OP_RETURNQUESTSTATE              ScrCmd_returnqueststate,            requests_effects=1  @ 0xe6
-    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7	
-		.if ALLOCATE_SCRIPT_CMD_TABLE
+    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7
+    script_cmd_table_entry SCR_OP_SETWARDROBE                   ScrCmd_setwardrobe,                 requests_effects=1  @ 0xe8
+    script_cmd_table_entry SCR_OP_GETWARDROBE                   ScrCmd_getwardrobe,                 requests_effects=1  @ 0xe9
+                .if ALLOCATE_SCRIPT_CMD_TABLE
 gScriptCmdTableEnd::
         .4byte ScrCmd_nop
         .endif

--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -250,11 +250,15 @@
 #define OBJ_EVENT_GFX_GRACE                      243
 #define OBJ_EVENT_GFX_PROF_OAK                   244
 #define OBJ_EVENT_GFX_PROF_ELM                   245
+#define OBJ_EVENT_GFX_WARDROBE_TOP               246
+#define OBJ_EVENT_GFX_WARDROBE_BOTTOM            247
+#define OBJ_EVENT_GFX_WARDROBE_HAIR              248
+#define OBJ_EVENT_GFX_WARDROBE_HAT               249
 
 // NOTE: The maximum amount of object events has been expanded from 255 to 65535.
 // Since dynamic graphics ids still require at least 16 free values, the actual limit
 // is 65519, but even considering follower Pokémon, this should be more than enough :)
-#define NUM_OBJ_EVENT_GFX                        246
+#define NUM_OBJ_EVENT_GFX                        250
 
 
 // These are dynamic object gfx ids.

--- a/include/global.h
+++ b/include/global.h
@@ -561,6 +561,16 @@ struct RankingHall2P
     //u8 padding;
 };
 
+#define WARDROBE_PIECE_DEFAULT 0
+
+struct Wardrobe
+{
+    u8 top;
+    u8 bottom;
+    u8 hair;
+    u8 hat;
+};
+
 // quest menu
 #include "constants/quests.h"
 
@@ -606,6 +616,7 @@ struct SaveBlock2
     // so that the larger arrays do not bloat SaveBlock1.
     u8 questData[(QUEST_COUNT * 5 + 7) / 8];
     u8 subQuests[(SUB_QUEST_COUNT + 7) / 8];
+    struct Wardrobe wardrobe;
 }; // sizeof=0xF2C
 
 extern struct SaveBlock2 *gSaveBlock2Ptr;

--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -2,6 +2,7 @@ POKEMONGFXDIR := graphics/pokemon
 OBJEVENTGFXDIR := graphics/object_events/pics
 FLDEFFGFXDIR := graphics/field_effects/pics
 MISCGFXDIR := graphics/misc
+CHARCUSTGFXDIR := graphics/trainers/character_customization
 
 $(OBJEVENTGFXDIR)/people/brendan/walking.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
@@ -4939,7 +4940,10 @@ $(POKEMONGFXDIR)/gourgeist/super/overworld.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 4 -mheight 4
 
 $(MISCGFXDIR)/emotes.4bpp: %.4bpp: %.png
-	$(GFX) $< $@ -mwidth 2 -mheight 2
+        $(GFX) $< $@ -mwidth 2 -mheight 2
+
+$(CHARCUSTGFXDIR)/%.4bpp: %.4bpp: %.png
+        $(GFX) $< $@ -mwidth 4 -mheight 4
 
 # All pokeballs are 16x32
 $(OBJEVENTGFXDIR)/misc/ball_%.4bpp: $(OBJEVENTGFXDIR)/misc/ball_%.png ; $(GFX) $< $@ -mwidth 2 -mheight 4

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1506,6 +1506,17 @@ u16 GetRivalAvatarGraphicsIdByStateIdAndGender(u8 state, u8 gender)
 
 u16 GetPlayerAvatarGraphicsIdByStateIdAndGender(u8 state, u8 gender)
 {
+    if (gSaveBlock2Ptr != NULL)
+    {
+        if (gSaveBlock2Ptr->wardrobe.top != WARDROBE_PIECE_DEFAULT)
+            return OBJ_EVENT_GFX_WARDROBE_TOP;
+        if (gSaveBlock2Ptr->wardrobe.bottom != WARDROBE_PIECE_DEFAULT)
+            return OBJ_EVENT_GFX_WARDROBE_BOTTOM;
+        if (gSaveBlock2Ptr->wardrobe.hair != WARDROBE_PIECE_DEFAULT)
+            return OBJ_EVENT_GFX_WARDROBE_HAIR;
+        if (gSaveBlock2Ptr->wardrobe.hat != WARDROBE_PIECE_DEFAULT)
+            return OBJ_EVENT_GFX_WARDROBE_HAT;
+    }
     return sPlayerAvatarGfxIds[state][gender];
 }
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3369,3 +3369,21 @@ bool8 ScrCmd_subquestmenu(struct ScriptContext *ctx)
 
     return TRUE;
 }
+
+bool8 ScrCmd_setwardrobe(struct ScriptContext *ctx)
+{
+    gSaveBlock2Ptr->wardrobe.top = VarGet(ScriptReadHalfword(ctx));
+    gSaveBlock2Ptr->wardrobe.bottom = VarGet(ScriptReadHalfword(ctx));
+    gSaveBlock2Ptr->wardrobe.hair = VarGet(ScriptReadHalfword(ctx));
+    gSaveBlock2Ptr->wardrobe.hat = VarGet(ScriptReadHalfword(ctx));
+    return FALSE;
+}
+
+bool8 ScrCmd_getwardrobe(struct ScriptContext *ctx)
+{
+    VarSet(ScriptReadHalfword(ctx), gSaveBlock2Ptr->wardrobe.top);
+    VarSet(ScriptReadHalfword(ctx), gSaveBlock2Ptr->wardrobe.bottom);
+    VarSet(ScriptReadHalfword(ctx), gSaveBlock2Ptr->wardrobe.hair);
+    VarSet(ScriptReadHalfword(ctx), gSaveBlock2Ptr->wardrobe.hat);
+    return FALSE;
+}


### PR DESCRIPTION
## Summary
- add Wardrobe struct in save data
- support compiling trainer customization graphics
- reserve object graphic IDs for wardrobe pieces
- load wardrobe sprite in field_player_avatar
- provide script commands `setwardrobe` and `getwardrobe`

## Testing
- `make check` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68846fccc75483239116da77a6695bce