### PR TITLE
Add warp signposts connecting towns

### DIFF
--- a/data/maps/LittlerootTown/map.json
+++ b/data/maps/LittlerootTown/map.json
@@ -267,6 +267,22 @@
       "elevation": 3,
       "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
       "script": "LittlerootTown_EventScript_MaysHouseSign"
+    },
+    {
+      "type": "sign",
+      "x": 10,
+      "y": 15,
+      "elevation": 0,
+      "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
+      "script": "LittlerootTown_EventScript_TeleportPallet"
+    },
+    {
+      "type": "sign",
+      "x": 12,
+      "y": 15,
+      "elevation": 0,
+      "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
+      "script": "LittlerootTown_EventScript_TeleportNewBark"
     }
   ]
 }

--- a/data/maps/LittlerootTown/scripts.inc
+++ b/data/maps/LittlerootTown/scripts.inc
@@ -416,12 +416,32 @@ LittlerootTown_EventScript_BirchsHouseSignFemale::
 	return
 
 LittlerootTown_EventScript_MaysHouseSign::
-	lockall
-	checkplayergender
-	call_if_eq VAR_RESULT, MALE, LittlerootTown_EventScript_BirchsHouseSignMale
-	call_if_eq VAR_RESULT, FEMALE, LittlerootTown_EventScript_PlayersHouseSignFemale
-	releaseall
-	end
+        lockall
+        checkplayergender
+        call_if_eq VAR_RESULT, MALE, LittlerootTown_EventScript_BirchsHouseSignMale
+        call_if_eq VAR_RESULT, FEMALE, LittlerootTown_EventScript_PlayersHouseSignFemale
+        releaseall
+        end
+
+LittlerootTown_EventScript_TeleportPallet::
+        lockall
+        msgbox LittlerootTown_Text_TeleportPallet, MSGBOX_YESNO
+        goto_if_eq VAR_RESULT, NO, LittlerootTown_EventScript_TeleportEnd
+        warpteleport MAP_PALLET_TOWN, 3, 10
+        waitstate
+        goto LittlerootTown_EventScript_TeleportEnd
+
+LittlerootTown_EventScript_TeleportNewBark::
+        lockall
+        msgbox LittlerootTown_Text_TeleportNewBark, MSGBOX_YESNO
+        goto_if_eq VAR_RESULT, NO, LittlerootTown_EventScript_TeleportEnd
+        warpteleport MAP_NEW_BARK_TOWN, 3, 10
+        waitstate
+        goto LittlerootTown_EventScript_TeleportEnd
+
+LittlerootTown_EventScript_TeleportEnd::
+        releaseall
+        end
 
 LittlerootTown_EventScript_BirchsHouseSignMale::
 	msgbox LittlerootTown_Text_ProfBirchsHouse, MSGBOX_DEFAULT
@@ -995,8 +1015,14 @@ LittlerootTown_Text_GoodLuckCatchingPokemon:
 	.string "Good luck!$"
 
 LittlerootTown_Text_TownSign:
-	.string "LITTLEROOT TOWN\n"
-	.string "“A town that can't be shaded any hue.”$"
+        .string "LITTLEROOT TOWN\n"
+        .string "“A town that can't be shaded any hue.”$"
+
+LittlerootTown_Text_TeleportPallet:
+        .string "Warp to PALLET TOWN?$"
+
+LittlerootTown_Text_TeleportNewBark:
+        .string "Warp to NEW BARK TOWN?$"
 
 LittlerootTown_Text_ProfBirchsLab:
 	.string "PROF. BIRCH'S POKéMON LAB$"

--- a/data/maps/NewBarkTown/map.json
+++ b/data/maps/NewBarkTown/map.json
@@ -125,6 +125,14 @@
       "elevation": 0,
       "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
       "script": "NewBarkTown_EventScript_TeleportLittleroot"
+    },
+    {
+      "type": "sign",
+      "x": 12,
+      "y": 15,
+      "elevation": 0,
+      "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
+      "script": "NewBarkTown_EventScript_TeleportPallet"
     }
   ]
 }

--- a/data/maps/NewBarkTown/scripts.inc
+++ b/data/maps/NewBarkTown/scripts.inc
@@ -123,6 +123,14 @@ NewBarkTown_EventScript_TeleportEnd::
         releaseall
         end
 
+NewBarkTown_EventScript_TeleportPallet::
+        lockall
+        msgbox NewBarkTown_Text_TeleportPallet, MSGBOX_YESNO
+        goto_if_eq VAR_RESULT, NO, NewBarkTown_EventScript_TeleportEnd
+        warpteleport MAP_PALLET_TOWN, 3, 10
+        waitstate
+        goto NewBarkTown_EventScript_TeleportEnd
+
 NewBarkTown_Text_YoureBack:
 	.string "MOM: {PLAYER}, you're back, honey!\p"
 	.string "It must be tiring riding with your things\n"
@@ -144,3 +152,6 @@ NewBarkTown_Text_PlayersHouseSign::
 
 NewBarkTown_Text_TeleportLittleroot:
         .string "Warp to LITTLEROOT TOWN?$"
+
+NewBarkTown_Text_TeleportPallet:
+        .string "Warp to PALLET TOWN?$"

--- a/data/maps/PalletTown/map.json
+++ b/data/maps/PalletTown/map.json
@@ -118,6 +118,14 @@
       "elevation": 0,
       "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
       "script": "PalletTown_EventScript_TeleportLittleroot"
+    },
+    {
+      "type": "sign",
+      "x": 10,
+      "y": 15,
+      "elevation": 0,
+      "player_facing_dir": "BG_EVENT_PLAYER_FACING_ANY",
+      "script": "PalletTown_EventScript_TeleportNewBark"
     }
   ]
 }

--- a/data/maps/PalletTown/scripts.inc
+++ b/data/maps/PalletTown/scripts.inc
@@ -123,6 +123,14 @@ PalletTown_EventScript_TeleportEnd::
         releaseall
         end
 
+PalletTown_EventScript_TeleportNewBark::
+        lockall
+        msgbox PalletTown_Text_TeleportNewBark, MSGBOX_YESNO
+        goto_if_eq VAR_RESULT, NO, PalletTown_EventScript_TeleportEnd
+        warpteleport MAP_NEW_BARK_TOWN, 3, 10
+        waitstate
+        goto PalletTown_EventScript_TeleportEnd
+
 PalletTown_Text_YoureBack:
 	.string "MOM: {PLAYER}, you're back, honey!\p"
 	.string "It must be tiring riding with your things\n"
@@ -144,3 +152,6 @@ PalletTown_Text_TownSign::
 
 PalletTown_Text_TeleportLittleroot:
     .string "Warp to LITTLEROOT TOWN?$"
+
+PalletTown_Text_TeleportNewBark:
+    .string "Warp to NEW BARK TOWN?$"


### PR DESCRIPTION
## Summary
- connect Littleroot, Pallet and New Bark Towns via warp signposts

## Testing
- `make check` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6884c712d1cc832380a557d410d31f1d