### PR TITLE
Fix region map template for missing names

### DIFF
--- a/src/data/region_map/region_map_sections.json.txt
+++ b/src/data/region_map/region_map_sections.json.txt
@@ -3,39 +3,51 @@
 #define GUARD_DATA_REGION_MAP_REGION_MAP_ENTRIES_H
 
 ## for map_section in map_sections
+{% if existsIn(map_section, "name") %}
 {% if isEmptyString(getVar(map_section.name)) and not existsIn(map_section, "name_clone") %}{{ setVar(map_section.name, map_section.map_section) }}{% endif %}
+{% endif %}
 ## endfor
 
 ## for map_section in map_sections
+{% if existsIn(map_section, "name") %}
 {% if getVar(map_section.name) == map_section.map_section %}
 static const u8 sMapName_{{ cleanString(map_section.name) }}[] = _("{{ map_section.name }}");
 {% endif %}
 {% if existsIn(map_section, "name_clone") %}
 static const u8 sMapName_{{ cleanString(map_section.name) }}_Clone[] = _("{{ map_section.name }}");
 {% endif %}
+{% endif %}
 ## endfor
 
 const struct RegionMapLocation gRegionMapEntries[] = {
 ## for map_section in map_sections
+{% if existsIn(map_section, "name") %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
 ## endfor
 };
 
 const struct RegionMapLocation gRegionMapEntries_Johto[] = {
 ## for map_section in map_sections_johto
+{% if existsIn(map_section, "name") %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
 ## endfor
 };
 
 const struct RegionMapLocation gRegionMapEntries_Kanto[] = {
 ## for map_section in map_sections_kanto
+{% if existsIn(map_section, "name") %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
 ## endfor
 };
 
 const struct RegionMapLocation gRegionMapEntries_Sevii[] = {
 ## for map_section in map_sections_sevii
+{% if existsIn(map_section, "name") %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+{% endif %}
 ## endfor
 };
 


### PR DESCRIPTION
## Summary
- guard blocks in `region_map_sections.json.txt` that assume `map_section.name`
- allow jsonproc to run without section names

## Testing
- `make -j$(nproc)` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688689ee98048323b28de97dc260d82a