### PR TITLE
Add warps between regions

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_1F/map.json
+++ b/data/maps/LittlerootTown_PlayersHouse_1F/map.json
@@ -82,6 +82,20 @@
       "elevation": 0,
       "dest_map": "MAP_NEW_BARK_TOWN",
       "dest_warp_id": "0"
+    },
+    {
+      "x": 9,
+      "y": 2,
+      "elevation": 0,
+      "dest_map": "MAP_PALLET_TOWN_PLAYERS_HOUSE_1F",
+      "dest_warp_id": "2"
+    },
+    {
+      "x": 7,
+      "y": 2,
+      "elevation": 0,
+      "dest_map": "MAP_TWINLEAF_TOWN_MAIN_HOUSE_1F",
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [
@@ -95,7 +109,5 @@
       "script": "LittlerootTown_PlayersHouse_1F_EventScript_GoSeeRoom"
     }
   ],
-  "bg_events": [
-
-  ]
+  "bg_events": []
 }

--- a/data/maps/NewBarkTown_PlayersHouse_1F/map.json
+++ b/data/maps/NewBarkTown_PlayersHouse_1F/map.json
@@ -68,6 +68,13 @@
       "elevation": 0,
       "dest_map": "MAP_NEW_BARK_TOWN",
       "dest_warp_id": "1"
+    },
+    {
+      "x": 10,
+      "y": 2,
+      "elevation": 0,
+      "dest_map": "MAP_LITTLEROOT_TOWN_PLAYERS_HOUSE_1F",
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [
@@ -81,7 +88,5 @@
       "script": "NewBarkTown_PlayersHouse_1F_EventScript_GoSeeRoom"
     }
   ],
-  "bg_events": [
-
-  ]
+  "bg_events": []
 }

--- a/data/maps/PalletTown_PlayersHouse_1F/map.json
+++ b/data/maps/PalletTown_PlayersHouse_1F/map.json
@@ -68,6 +68,13 @@
       "elevation": 0,
       "dest_map": "MAP_PALLET_TOWN_PLAYERS_HOUSE_2F",
       "dest_warp_id": "0"
+    },
+    {
+      "x": 10,
+      "y": 2,
+      "elevation": 0,
+      "dest_map": "MAP_LITTLEROOT_TOWN_PLAYERS_HOUSE_1F",
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [
@@ -81,7 +88,5 @@
       "script": "PalletTown_PlayersHouse_1F_EventScript_GoSeeRoom"
     }
   ],
-  "bg_events": [
-
-  ]
+  "bg_events": []
 }

--- a/data/maps/TwinleafTown_MainHouse_1F/map.json
+++ b/data/maps/TwinleafTown_MainHouse_1F/map.json
@@ -13,9 +13,7 @@
   "show_map_name": false,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": 0,
-  "object_events": [
-
-  ],
+  "object_events": [],
   "warp_events": [
     {
       "x": 2,
@@ -37,12 +35,15 @@
       "elevation": 0,
       "dest_map": "MAP_TWINLEAF_TOWN_MAIN_HOUSE_2F",
       "dest_warp_id": "0"
+    },
+    {
+      "x": 9,
+      "y": 2,
+      "elevation": 0,
+      "dest_map": "MAP_LITTLEROOT_TOWN_PLAYERS_HOUSE_1F",
+      "dest_warp_id": "5"
     }
   ],
-  "coord_events": [
-
-  ],
-  "bg_events": [
-
-  ]
+  "coord_events": [],
+  "bg_events": []
 }


### PR DESCRIPTION
## Summary
- connect Littleroot house to Pallet, New Bark and Twinleaf houses
- link each destination back to Littleroot

## Testing
- `make -j$(nproc)` *(fails: several missing map constants in heal_locations.h)*

------
https://chatgpt.com/codex/tasks/task_e_68869a804ca8832397eb96ec53fcc94f