### PR TITLE
Add Sinnoh outdoor tileset

### DIFF
--- a/include/tilesets.h
+++ b/include/tilesets.h
@@ -12,5 +12,6 @@ extern const struct Tileset gTileset_BrendansMaysHouse;
 
 extern const struct Tileset gTileset_SinnohGeneral;
 extern const struct Tileset gTileset_SinnohBuilding;
+extern const struct Tileset gTileset_SinnohOutdoor;
 
 #endif //GUARD_tilesets_H

--- a/src/data/tilesets/graphics.h
+++ b/src/data/tilesets/graphics.h
@@ -1748,6 +1748,25 @@ const u16 gTilesetPalettes_SinnohBuilding[][16] =
         INCBIN_U16("data/tilesets/primary/sinnohbuilding/palettes/12.gbapal"),
 };
 
+const u32 gTilesetTiles_SinnohOutdoor[] = INCBIN_U32("data/tilesets/primary/outdoor/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_SinnohOutdoor[][16] =
+{
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/00.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/01.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/02.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/03.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/04.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/05.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/06.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/07.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/08.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/09.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/10.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/11.gbapal"),
+        INCBIN_U16("data/tilesets/primary/outdoor/palettes/12.gbapal"),
+};
+
 const u32 gTilesetTiles_CeladonCity[] = INCBIN_U32("data/tilesets/secondary/celadoncity/tiles.4bpp.lz");
 
 const u16 gTilesetPalettes_CeladonCity[][16] =

--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -897,6 +897,17 @@ const struct Tileset gTileset_SinnohBuilding =
     .callback = NULL,
 };
 
+const struct Tileset gTileset_SinnohOutdoor =
+{
+    .isCompressed = TRUE,
+    .isSecondary = FALSE,
+    .tiles = gTilesetTiles_SinnohOutdoor,
+    .palettes = gTilesetPalettes_SinnohOutdoor,
+    .metatiles = gMetatiles_SinnohOutdoor,
+    .metatileAttributes = gMetatileAttributes_SinnohOutdoor,
+    .callback = NULL,
+};
+
 const struct Tileset gTileset_CeladonCity =
 {
     .isCompressed = TRUE,

--- a/src/data/tilesets/metatiles.h
+++ b/src/data/tilesets/metatiles.h
@@ -226,6 +226,9 @@ const u16 gMetatileAttributes_SinnohGeneral[] = INCBIN_U16("data/tilesets/primar
 const u16 gMetatiles_SinnohBuilding[] = INCBIN_U16("data/tilesets/primary/sinnohbuilding/metatiles.bin");
 const u16 gMetatileAttributes_SinnohBuilding[] = INCBIN_U16("data/tilesets/primary/sinnohbuilding/metatile_attributes.bin");
 
+const u16 gMetatiles_SinnohOutdoor[] = INCBIN_U16("data/tilesets/primary/outdoor/metatiles.bin");
+const u16 gMetatileAttributes_SinnohOutdoor[] = INCBIN_U16("data/tilesets/primary/outdoor/metatile_attributes.bin");
+
 const u16 gMetatiles_CeladonCity[] = INCBIN_U16("data/tilesets/secondary/celadoncity/metatiles.bin");
 const u16 gMetatileAttributes_CeladonCity[] = INCBIN_U16("data/tilesets/secondary/celadoncity/metatile_attributes.bin");
 


### PR DESCRIPTION
## Summary
- declare `gTileset_SinnohOutdoor` in header
- reference Sinnoh outdoor graphics and palettes
- reference outdoor metatiles
- define the new tileset struct

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688782fa3abc83239fc9cf960737c05c