### PR TITLE
Add Twinleaf tileset

### DIFF
--- a/include/tilesets.h
+++ b/include/tilesets.h
@@ -13,4 +13,6 @@ extern const struct Tileset gTileset_BrendansMaysHouse;
 extern const struct Tileset gTileset_SinnohGeneral;
 extern const struct Tileset gTileset_SinnohBuilding;
 
+extern const struct Tileset gTileset_Twinleaf;
+
 #endif //GUARD_tilesets_H

--- a/src/data/tilesets/graphics.h
+++ b/src/data/tilesets/graphics.h
@@ -3283,9 +3283,28 @@ const u16 gTilesetPalettes_CeruleanCave[][16] =
 	INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/08.gbapal"),
 	INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/09.gbapal"),
 	INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/10.gbapal"),
-	INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/11.gbapal"),
-	INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/12.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/ceruleancave/palettes/12.gbapal"),
 };
+
+const u16 gTilesetPalettes_Twinleaf[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/twinleaf/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_Twinleaf[] = INCBIN_U32("data/tilesets/secondary/twinleaf/tiles.4bpp.lz");
 
 const u16 gTilesetPalettes_Jubilife[][16] =
 {

--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -1788,6 +1788,17 @@ const struct Tileset gTileset_CeruleanCave =
     .callback = NULL,
 };
 
+const struct Tileset gTileset_Twinleaf =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_Twinleaf,
+    .palettes = gTilesetPalettes_Twinleaf,
+    .metatiles = gMetatiles_Twinleaf,
+    .metatileAttributes = gMetatileAttributes_Twinleaf,
+    .callback = NULL,
+};
+
 const struct Tileset gTileset_Jubilife =
 {
     .isCompressed = TRUE,

--- a/src/data/tilesets/metatiles.h
+++ b/src/data/tilesets/metatiles.h
@@ -469,6 +469,9 @@ const u16 gMetatileAttributes_DottedHole[] = INCBIN_U16("data/tilesets/secondary
 const u16 gMetatiles_CeruleanCave[] = INCBIN_U16("data/tilesets/secondary/ceruleancave/metatiles.bin");
 const u16 gMetatileAttributes_CeruleanCave[] = INCBIN_U16("data/tilesets/secondary/ceruleancave/metatile_attributes.bin");
 
+const u16 gMetatiles_Twinleaf[] = INCBIN_U16("data/tilesets/secondary/twinleaf/metatiles.bin");
+const u16 gMetatileAttributes_Twinleaf[] = INCBIN_U16("data/tilesets/secondary/twinleaf/metatile_attributes.bin");
+
 const u16 gMetatiles_Jubilife[] = INCBIN_U16("data/tilesets/secondary/jubilife/metatiles.bin");
 const u16 gMetatileAttributes_Jubilife[] = INCBIN_U16("data/tilesets/secondary/jubilife/metatile_attributes.bin");
 


### PR DESCRIPTION
## Summary
- declare `gTileset_Twinleaf`
- define Twinleaf tileset graphics and palettes
- add Twinleaf metatiles and attributes
- create `gTileset_Twinleaf` structure

## Testing
- `make tidy`
- `make -j$(nproc) check` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_688782fd3ee08323ada1ab86ed395b5b