### PR TITLE
Add porytiles build rule

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -179,6 +179,27 @@ If you targeted a specific version that is not the latest version listed on the 
 # Useful additional tools
 
 * [porymap](https://github.com/huderlem/porymap) for viewing and editing maps
-* [porytiles](https://github.com/gruntlucas/porytiles) for add new metatiles for maps
+* [porytiles](https://github.com/grunt-lucas/porytiles) for adding and compiling tilesets (see below)
 * [poryscript](https://github.com/huderlem/poryscript) for scripting ([VS Code extension](https://marketplace.visualstudio.com/items?itemName=karathan.poryscript))
 * [Tilemap Studio](https://github.com/Rangi42/tilemap-studio) for viewing and editing tilemaps
+
+### Installing porytiles
+
+porytiles is now included in this repository as a git submodule under
+`tools/porytiles`.
+After cloning, initialize the submodule:
+
+```bash
+git submodule update --init tools/porytiles
+```
+
+Build porytiles with CMake (requires `cmake` and a C++20 compiler):
+
+```bash
+cd tools/porytiles
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+The resulting `porytiles` executable will be inside the `build` directory and is
+used by the `make tilesets` rule.

--- a/Makefile
+++ b/Makefile
@@ -513,3 +513,8 @@ $(ROM): $(ELF)
 # Symbol file (`make syms`)
 $(SYM): $(ELF)
 	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+
+# Rebuild all tilesets using porytiles
+.PHONY: tilesets
+tilesets:
+	@./build_tilesets.sh

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you're new to git and GitHub, [Team Aqua's Asset Repo](https://github.com/Paw
 ## 📥 [Installing **`pokeemerald-expansion`**](INSTALL.md)
 ## 🏗️ [Building **`pokeemerald-expansion`**](INSTALL.md#Building-pokeemerald-expansion)
 * When adding new constants, you may need to run `make clean` before building so the changes are picked up.
+* Run `git submodule update --init tools/porytiles` once, then `make tilesets` (or `./build_tilesets.sh`) to rebuild all tilesets using the bundled [porytiles](https://github.com/grunt-lucas/porytiles).
 ## 🚚 [Migrating from **`pokeemerald`**](INSTALL.md#Migrating-from-pokeemerald)
 ## 🚀 [Updating **`pokeemerald-expansion`**](INSTALL.md#Updating-pokeemerald-expansion)
 

--- a/build_tilesets.sh
+++ b/build_tilesets.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+COMMANDS_FILE="$SCRIPT_DIR/tiles/commands.txt"
+# Path to the porytiles executable built from the submodule
+PORYTILES="$SCRIPT_DIR/tools/porytiles/build/Porytiles1/tools/driver/porytiles"
+[ -x "$PORYTILES" ] || PORYTILES="$SCRIPT_DIR/tools/porytiles/porytiles"
+
+if [ ! -x "$PORYTILES" ]; then
+    echo "Error: porytiles binary not found. Build it in tools/porytiles." >&2
+    exit 1
+fi
+
+while IFS= read -r cmd; do
+    [ -z "$cmd" ] && continue
+    echo "$PORYTILES ${cmd#porytiles }"
+    "$PORYTILES" ${cmd#porytiles }
+done < "$COMMANDS_FILE"
+


### PR DESCRIPTION
## Summary
- document how to obtain porytiles from the submodule
- update tileset rebuilding instructions
- make build_tilesets.sh use the local porytiles binary

## Testing
- `bash -n build_tilesets.sh`
- `./build_tilesets.sh` *(fails: porytiles binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b152af808323957ed6b9524dd15c