### PR TITLE
Fix region map name generation for empty entries

### DIFF
--- a/src/data/region_map/region_map_sections.json.txt
+++ b/src/data/region_map/region_map_sections.json.txt
@@ -3,13 +3,13 @@
 #define GUARD_DATA_REGION_MAP_REGION_MAP_ENTRIES_H
 
 ## for map_section in map_sections
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
 {% if isEmptyString(getVar(map_section.name)) and not existsIn(map_section, "name_clone") %}{{ setVar(map_section.name, map_section.map_section) }}{% endif %}
 {% endif %}
 ## endfor
 
 ## for map_section in map_sections
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
 {% if getVar(map_section.name) == map_section.map_section %}
 static const u8 sMapName_{{ cleanString(map_section.name) }}[] = _("{{ map_section.name }}");
 {% endif %}
@@ -21,7 +21,7 @@ static const u8 sMapName_{{ cleanString(map_section.name) }}_Clone[] = _("{{ map
 
 const struct RegionMapLocation gRegionMapEntries[] = {
 ## for map_section in map_sections
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
 {% endif %}
 ## endfor
@@ -29,7 +29,7 @@ const struct RegionMapLocation gRegionMapEntries[] = {
 
 const struct RegionMapLocation gRegionMapEntries_Johto[] = {
 ## for map_section in map_sections_johto
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
 {% endif %}
 ## endfor
@@ -37,7 +37,7 @@ const struct RegionMapLocation gRegionMapEntries_Johto[] = {
 
 const struct RegionMapLocation gRegionMapEntries_Kanto[] = {
 ## for map_section in map_sections_kanto
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
 {% endif %}
 ## endfor
@@ -45,7 +45,7 @@ const struct RegionMapLocation gRegionMapEntries_Kanto[] = {
 
 const struct RegionMapLocation gRegionMapEntries_Sevii[] = {
 ## for map_section in map_sections_sevii
-{% if existsIn(map_section, "name") %}
+{% if existsIn(map_section, "name") and not isEmptyString(map_section.name) %}
     [{{ map_section.map_section }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
 {% endif %}
 ## endfor


### PR DESCRIPTION
## Summary
- avoid generating invalid `sMapName_` identifiers for map sections without names

## Testing
- `make check -j4` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6887c2507df4832388bb031a0d3199dd