### PR TITLE
Add new tileset data

### DIFF
--- a/graphics_file_rules.mk
+++ b/graphics_file_rules.mk
@@ -220,6 +220,27 @@ $(TILESETGFXDIR)/secondary/battle_frontier_ranking_hall/tiles.4bpp: %.4bpp: %.pn
 $(TILESETGFXDIR)/secondary/mystery_events_house/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 509 -Wnum_tiles
 
+$(TILESETGFXDIR)/primary/Caves\ Alt\ Primary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 480 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Caves\ Alt\ Secondary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 288 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Gate\ Platinum\ Secondary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 80 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Shady\ Forest\ Secondary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 512 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Space\ Meteor\ Secondary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 272 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Underwater\ Primary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 512 -Wnum_tiles
+
+$(TILESETGFXDIR)/secondary/Underwater\ Reef\ Secondary/tiles.4bpp: %.4bpp: %.png
+	$(GFX) $< $@ -num_tiles 352 -Wnum_tiles
+
 
 
 ### Fonts ###

--- a/src/data/tilesets/graphics.h
+++ b/src/data/tilesets/graphics.h
@@ -3476,3 +3476,136 @@ const u16 gTilesetPalettes_Distortion[][16] =
 };
 
 const u32 gTilesetTiles_Distortion[] = INCBIN_U32("data/tilesets/secondary/distortion/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_CavesAltPrimary[][16] =
+{
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/primary/Caves Alt Primary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_CavesAltPrimary[] = INCBIN_U32("data/tilesets/primary/Caves Alt Primary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_CavesAltSecondary[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_CavesAltSecondary[] = INCBIN_U32("data/tilesets/secondary/Caves Alt Secondary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_GatePlatinum[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_GatePlatinum[] = INCBIN_U32("data/tilesets/secondary/Gate Platinum Secondary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_ShadyForest[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_ShadyForest[] = INCBIN_U32("data/tilesets/secondary/Shady Forest Secondary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_SpaceMeteor[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_SpaceMeteor[] = INCBIN_U32("data/tilesets/secondary/Space Meteor Secondary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_UnderwaterPrimary[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Primary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_UnderwaterPrimary[] = INCBIN_U32("data/tilesets/secondary/Underwater Primary/tiles.4bpp.lz");
+
+const u16 gTilesetPalettes_UnderwaterReef[][16] =
+{
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/01.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/02.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/03.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/04.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/05.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/06.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/07.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/08.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/09.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/10.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/11.gbapal"),
+    INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/palettes/12.gbapal"),
+};
+
+const u32 gTilesetTiles_UnderwaterReef[] = INCBIN_U32("data/tilesets/secondary/Underwater Reef Secondary/tiles.4bpp.lz");

--- a/src/data/tilesets/headers.h
+++ b/src/data/tilesets/headers.h
@@ -1897,3 +1897,80 @@ const struct Tileset gTileset_Distortion =
     .metatileAttributes = gMetatileAttributes_Distortion,
     .callback = NULL,
 };
+
+const struct Tileset gTileset_CavesAltPrimary =
+{
+    .isCompressed = TRUE,
+    .isSecondary = FALSE,
+    .tiles = gTilesetTiles_CavesAltPrimary,
+    .palettes = gTilesetPalettes_CavesAltPrimary,
+    .metatiles = gMetatiles_CavesAltPrimary,
+    .metatileAttributes = gMetatileAttributes_CavesAltPrimary,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_CavesAltSecondary =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_CavesAltSecondary,
+    .palettes = gTilesetPalettes_CavesAltSecondary,
+    .metatiles = gMetatiles_CavesAltSecondary,
+    .metatileAttributes = gMetatileAttributes_CavesAltSecondary,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_GatePlatinum =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_GatePlatinum,
+    .palettes = gTilesetPalettes_GatePlatinum,
+    .metatiles = gMetatiles_GatePlatinum,
+    .metatileAttributes = gMetatileAttributes_GatePlatinum,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_ShadyForest =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_ShadyForest,
+    .palettes = gTilesetPalettes_ShadyForest,
+    .metatiles = gMetatiles_ShadyForest,
+    .metatileAttributes = gMetatileAttributes_ShadyForest,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_SpaceMeteor =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_SpaceMeteor,
+    .palettes = gTilesetPalettes_SpaceMeteor,
+    .metatiles = gMetatiles_SpaceMeteor,
+    .metatileAttributes = gMetatileAttributes_SpaceMeteor,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_UnderwaterPrimary =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_UnderwaterPrimary,
+    .palettes = gTilesetPalettes_UnderwaterPrimary,
+    .metatiles = gMetatiles_UnderwaterPrimary,
+    .metatileAttributes = gMetatileAttributes_UnderwaterPrimary,
+    .callback = NULL,
+};
+
+const struct Tileset gTileset_UnderwaterReef =
+{
+    .isCompressed = TRUE,
+    .isSecondary = TRUE,
+    .tiles = gTilesetTiles_UnderwaterReef,
+    .palettes = gTilesetPalettes_UnderwaterReef,
+    .metatiles = gMetatiles_UnderwaterReef,
+    .metatileAttributes = gMetatileAttributes_UnderwaterReef,
+    .callback = NULL,
+};

--- a/src/data/tilesets/metatiles.h
+++ b/src/data/tilesets/metatiles.h
@@ -498,3 +498,24 @@ const u16 gMetatileAttributes_Pasos[] = INCBIN_U16("data/tilesets/secondary/paso
 
 const u16 gMetatiles_Distortion[] = INCBIN_U16("data/tilesets/secondary/distortion/metatiles.bin");
 const u16 gMetatileAttributes_Distortion[] = INCBIN_U16("data/tilesets/secondary/distortion/metatile_attributes.bin");
+
+const u16 gMetatiles_CavesAltPrimary[] = INCBIN_U16("data/tilesets/primary/Caves Alt Primary/metatiles.bin");
+const u16 gMetatileAttributes_CavesAltPrimary[] = INCBIN_U16("data/tilesets/primary/Caves Alt Primary/metatile_attributes.bin");
+
+const u16 gMetatiles_CavesAltSecondary[] = INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/metatiles.bin");
+const u16 gMetatileAttributes_CavesAltSecondary[] = INCBIN_U16("data/tilesets/secondary/Caves Alt Secondary/metatile_attributes.bin");
+
+const u16 gMetatiles_GatePlatinum[] = INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/metatiles.bin");
+const u16 gMetatileAttributes_GatePlatinum[] = INCBIN_U16("data/tilesets/secondary/Gate Platinum Secondary/metatile_attributes.bin");
+
+const u16 gMetatiles_ShadyForest[] = INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/metatiles.bin");
+const u16 gMetatileAttributes_ShadyForest[] = INCBIN_U16("data/tilesets/secondary/Shady Forest Secondary/metatile_attributes.bin");
+
+const u16 gMetatiles_SpaceMeteor[] = INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/metatiles.bin");
+const u16 gMetatileAttributes_SpaceMeteor[] = INCBIN_U16("data/tilesets/secondary/Space Meteor Secondary/metatile_attributes.bin");
+
+const u16 gMetatiles_UnderwaterPrimary[] = INCBIN_U16("data/tilesets/secondary/Underwater Primary/metatiles.bin");
+const u16 gMetatileAttributes_UnderwaterPrimary[] = INCBIN_U16("data/tilesets/secondary/Underwater Primary/metatile_attributes.bin");
+
+const u16 gMetatiles_UnderwaterReef[] = INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/metatiles.bin");
+const u16 gMetatileAttributes_UnderwaterReef[] = INCBIN_U16("data/tilesets/secondary/Underwater Reef Secondary/metatile_attributes.bin");


### PR DESCRIPTION
## Summary
- add graphics/palette/tileset data for Caves Alt and Underwater variants
- wire new tilesets in headers and metatile tables
- include conversion rules for new tileset graphics

## Testing
- `make tools -j$(nproc)` *(fails: `arm-none-eabi-gcc` not found)*
- `make check -j$(nproc)` *(fails: `arm-none-eabi-cpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882fbb2b348323b5ed8b9830a14002