### PR TITLE
Fix missing tabs causing make error

### DIFF
--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -143,7 +143,7 @@ $(OBJEVENTGFXDIR)/people/dawn/watering.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 4 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/dawn/decorating.4bpp: %.4bpp: %.png
-       $(GFX) $< $@ -mwidth 2 -mheight 4
+	$(GFX) $< $@ -mwidth 2 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/lucas/walking.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
@@ -188,7 +188,7 @@ $(OBJEVENTGFXDIR)/people/gold/underwater.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 4 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/gold/decorating.4bpp: %.4bpp: %.png
-       $(GFX) $< $@ -mwidth 2 -mheight 4
+	$(GFX) $< $@ -mwidth 2 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/lyra/walking.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
@@ -218,7 +218,7 @@ $(OBJEVENTGFXDIR)/people/lyra/underwater.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 4 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/lyra/decorating.4bpp: %.4bpp: %.png
-       $(GFX) $< $@ -mwidth 2 -mheight 4
+	$(GFX) $< $@ -mwidth 2 -mheight 4
 
 $(OBJEVENTGFXDIR)/people/ruby_sapphire_brendan/walking.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4


### PR DESCRIPTION
## Summary
- repair the rule lines in `spritesheet_rules.mk` that had spaces instead of tabs

## Testing
- `make` *(fails: `arm-none-eabi-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a630de0848323b23600f0a06978e7