### PR TITLE
Fix indentation for youngster sprite rule

### DIFF
--- a/spritesheet_rules.mk
+++ b/spritesheet_rules.mk
@@ -512,7 +512,7 @@ $(OBJEVENTGFXDIR)/people/link_receptionist.4bpp: %.4bpp: %.png
 $(OBJEVENTGFXDIR)/people/woman_5.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
-	$(OBJEVENTGFXDIR)/people/youngster.4bpp: %.4bpp: %.png
+$(OBJEVENTGFXDIR)/people/youngster.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -mwidth 2 -mheight 4
 
 # Platinum


### PR DESCRIPTION
## Summary
- fix `youngster.4bpp` Makefile rule indentation so make interprets the rule correctly

## Testing
- `make tools -j4`
- `make build/modern/src/event_object_movement.o` *(fails: warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a6a7049688323a13ff83d0cd95089