### PR TITLE
Fix DrawMetatile parameter names

### DIFF
--- a/src/field_camera.c
+++ b/src/field_camera.c
@@ -30,7 +30,7 @@ static void RedrawMapSliceWest(struct FieldCameraOffset *, const struct MapLayou
 static s32 MapPosToBgTilemapOffset(struct FieldCameraOffset *, s32, s32);
 static void DrawWholeMapViewInternal(int, int, const struct MapLayout *);
 static void DrawMetatileAt(const struct MapLayout *, u16, int, int);
-static void DrawMetatile(s32, const u16 *, u16);
+static void DrawMetatile(s32 metatileLayerType, const u16 *tiles, u16 offset);
 static void CameraPanningCB_PanAhead(void);
 
 static struct FieldCameraOffset sFieldCameraOffset;
@@ -242,7 +242,7 @@ static void DrawMetatileAt(const struct MapLayout *mapLayout, u16 offset, int x,
     DrawMetatile(MapGridGetMetatileLayerTypeAt(x, y), metatiles + metatileId * NUM_TILES_PER_METATILE, offset);
 }
 
-static void DrawMetatile(s32, const u16 *, u16)
+static void DrawMetatile(s32 metatileLayerType, const u16 *tiles, u16 offset)
 {
     if (metatileLayerType == 0xFF)
     {


### PR DESCRIPTION
## Summary
- add missing parameter names to `DrawMetatile`

## Testing
- `make -B build/modern/src/field_camera.o`

------
https://chatgpt.com/codex/tasks/task_e_688a81c90b748323bfd25f96c05af0e0