### PR TITLE
Fix missing rival sprite after truck intro

### DIFF
--- a/data/maps/LittlerootTown/scripts.inc
+++ b/data/maps/LittlerootTown/scripts.inc
@@ -142,6 +142,7 @@ LittlerootTown_EventScript_GoInsideWithRival::
         opendoor VAR_0x8004, VAR_0x8005
         waitdooranim
         addobject LOCALID_LITTLEROOT_RIVAL
+        setobjectxy LOCALID_LITTLEROOT_RIVAL, VAR_0x8004, VAR_0x8005
         applymovement LOCALID_LITTLEROOT_RIVAL, LittlerootTown_Movement_MomExitHouse
         waitmovement 0
         closedoor VAR_0x8004, VAR_0x8005


### PR DESCRIPTION
## Summary
- ensure Littleroot rival spawns at the proper door by setting its coordinates before exit

## Testing
- `make -j$(nproc)` *(fails: build interrupted after partial compilation)*

------
https://chatgpt.com/codex/tasks/task_e_688b812b9474832384ce84c63aae957a