### PR TITLE
feat: support second rival name placeholder

### DIFF
--- a/charmap.txt
+++ b/charmap.txt
@@ -350,6 +350,7 @@ ARCHIE         = FD 0A
 MAXIE          = FD 0B
 KYOGRE         = FD 0C
 GROUDON        = FD 0D
+OTHER_RIVAL    = FD 0E
 
 @ battle string placeholders
 

--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -307,24 +307,39 @@ PlayersHouse_1F_Text_GoSetTheClock:
 	.string "Go set the clock in your room, honey.$"
 
 PlayersHouse_1F_Text_OhComeQuickly:
-	.string "MOM: Oh! {PLAYER}, {PLAYER}!\n"
-	.string "Quick! Come quickly!$"
+        .string "{RIVAL}: {PLAYER}! Quick, come\n"
+        .string "downstairs! You have to see\l"
+        .string "this!$"
 
 PlayersHouse_1F_Text_MaybeDadWillBeOn:
-	.string "MOM: Look! It's PETALBURG GYM!\n"
-	.string "Maybe DAD will be on!$"
+        .string "TV: Breaking news! A link\n"
+        .string "between HOENN and JOHTO is\l"
+        .string "being developed!$"
 
 PlayersHouse_1F_Text_ItsOverWeMissedHim:
-	.string "MOM: Oh… It's over.\p"
-	.string "I think DAD was on, but we missed him.\n"
-	.string "Too bad.$"
+        .string "MOM: Goodness gracious!\p"
+        .string "HOENN and JOHTO... connected?\n"
+        .string "I never thought I'd see the\l"
+        .string "day!$"
 
 PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor:
-	.string "Oh, yes.\n"
-	.string "One of DAD's friends lives in town.\p"
-	.string "PROF. BIRCH is his name.\p"
-	.string "He lives right next door, so you should\n"
-	.string "go over and introduce yourself.$"
+        .string "{RIVAL}: This is incredible!\p"
+        .string "Imagine all the new POKéMON\n"
+        .string "and TRAINERS we'll meet!$"
+
+PlayersHouse_1F_Text_PlayerFeelsBigChange:
+        .string "{PLAYER}: Wow... This feels\n"
+        .string "like the start of something\l"
+        .string "big. I wonder if this has\n"
+        .string "anything to do with the\l"
+        .string "changes I felt coming\n"
+        .string "back here...$"
+
+PlayersHouse_1F_Text_RivalInvitation:
+        .string "{RIVAL}: Come on, {PLAYER}!\n"
+        .string "Let's go outside. There's\l"
+        .string "someone next door who's\n"
+        .string "eager to meet you!$"
 
 PlayersHouse_1F_Text_SeeYouHoney:
 	.string "MOM: See you, honey!$"
@@ -368,8 +383,10 @@ PlayersHouse_1F_Text_Vigoroth2:
 	.string "Huggoh, uggo uggo…$"
 
 PlayersHouse_1F_Text_ReportFromPetalburgGym:
-	.string "INTERVIEWER: …We brought you this\n"
-	.string "report from in front of PETALBURG GYM.$"
+        .string "REPORTER: Experts say this\n"
+        .string "could open travel between the\l"
+        .string "regions for the first time\n"
+        .string "in history.$"
 
 PlayersHouse_1F_Text_TheresAMovieOnTV:
 	.string "There is a movie on TV.\p"

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -91,14 +91,17 @@ LittlerootTown_MaysHouse_1F_EventScript_YoureNewNeighbor::
 	applymovement LOCALID_RIVALS_HOUSE_1F_MOM, Common_Movement_Delay48
 	waitmovement 0
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
-	applymovement LOCALID_RIVALS_HOUSE_1F_MOM, LittlerootTown_MaysHouse_1F_Movement_RivalMomApproach
-	waitmovement 0
-	special GetRivalSonDaughterString
-	msgbox RivalsHouse_1F_Text_OhYoureTheNewNeighbor, MSGBOX_DEFAULT
-	setflag FLAG_MET_RIVAL_MOM
-	setvar VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 2
-	releaseall
-	end
+        applymovement LOCALID_RIVALS_HOUSE_1F_MOM, LittlerootTown_MaysHouse_1F_Movement_RivalMomApproach
+        waitmovement 0
+        special GetRivalSonDaughterString
+        msgbox RivalsHouse_1F_Text_OhYoureTheNewNeighbor, MSGBOX_DEFAULT
+        msgbox RivalsHouse_1F_Text_PlayerFeelsDifferent, MSGBOX_DEFAULT
+        msgbox RivalsHouse_1F_Text_WellWelcomeHome, MSGBOX_DEFAULT
+        msgbox RivalsHouse_1F_Text_ComeSeeRoom, MSGBOX_DEFAULT
+        setflag FLAG_MET_RIVAL_MOM
+        setvar VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 2
+        releaseall
+        end
 
 LittlerootTown_MaysHouse_1F_Movement_RivalMomApproach:
 	walk_down
@@ -317,16 +320,25 @@ LittlerootTown_MaysHouse_1F_Movement_MayGoUpstairs2:
 	step_end
 
 RivalsHouse_1F_Text_OhYoureTheNewNeighbor:
-	.string "Oh, hello. And you are?\p"
-	.string "… … … … … … … … …\n"
-	.string "… … … … … … … … …\p"
-	.string "Oh, you're {PLAYER}{KUN}, our new next-door\n"
-	.string "neighbor! Hi!\p"
-	.string "We have a {STR_VAR_1} about the same\n"
-	.string "age as you.\p"
-	.string "Our {STR_VAR_1} was excited about making\n"
-	.string "a new friend.\p"
-	.string "Our {STR_VAR_1} is upstairs, I think.$"
+        .string "Oh my! {PLAYER}, is that really you?\p"
+        .string "It feels like just yesterday you were\n"
+        .string "running around with {RIVAL} and\l"
+        .string "{OTHER_RIVAL} in the yard. I can't\p"
+        .string "believe it's been eight years!$"
+
+RivalsHouse_1F_Text_PlayerFeelsDifferent:
+        .string "Yeah... it feels like a lifetime ago.\p"
+        .string "LITTLEROOT feels familiar, but\n"
+        .string "different somehow.$"
+
+RivalsHouse_1F_Text_WellWelcomeHome:
+        .string "Well, welcome home! We're so happy to\n"
+        .string "have you staying with us again. I'm\l"
+        .string "sure you'll settle in quickly.$"
+
+RivalsHouse_1F_Text_ComeSeeRoom:
+        .string "Come on, {PLAYER}! Let me show you\n"
+        .string "your room upstairs.$"
 
 RivalsHouse_1F_Text_LikeChildLikeFather:
 	.string "Like child, like father.\p"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -157,13 +157,15 @@ PlayersHouse_1F_EventScript_PetalburgGymReportMale::
 	waitmovement 0
 	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVMale
 	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
-	msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
-	closemessage
-	setvar VAR_TEMP_1, 1
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PlayerFeelsBigChange, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_RivalInvitation, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_TEMP_1, 1
 	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatMale
 	waitmovement 0
 	goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
@@ -182,13 +184,15 @@ PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
 	waitmovement 0
 	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVFemale
 	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
-	msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
-	closemessage
-	setvar VAR_TEMP_1, 1
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PlayerFeelsBigChange, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_RivalInvitation, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_TEMP_1, 1
 	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatFemale
 	waitmovement 0
 	goto PlayersHouse_1F_EventScript_SetWatchedBroadcast

--- a/include/constants/characters.h
+++ b/include/constants/characters.h
@@ -264,6 +264,7 @@
 #define PLACEHOLDER_ID_MAXIE         0xB
 #define PLACEHOLDER_ID_KYOGRE        0xC
 #define PLACEHOLDER_ID_GROUDON       0xD
+#define PLACEHOLDER_ID_OTHER_RIVAL   0xE
 
 // battle placeholders are located in battle_message.h
 

--- a/src/string_util.c
+++ b/src/string_util.c
@@ -486,6 +486,14 @@ static const u8 *ExpandPlaceholder_RivalName(void)
         return gText_ExpandedPlaceholder_Brendan;
 }
 
+static const u8 *ExpandPlaceholder_OtherRivalName(void)
+{
+    if (gSaveBlock2Ptr->playerGender == MALE)
+        return gText_ExpandedPlaceholder_Brendan;
+    else
+        return gText_ExpandedPlaceholder_May;
+}
+
 static const u8 *ExpandPlaceholder_Version(void)
 {
     return gText_ExpandedPlaceholder_Emerald;
@@ -541,6 +549,7 @@ const u8 *GetExpandedPlaceholder(u32 id)
         [PLACEHOLDER_ID_MAXIE]        = ExpandPlaceholder_Maxie,
         [PLACEHOLDER_ID_KYOGRE]       = ExpandPlaceholder_Kyogre,
         [PLACEHOLDER_ID_GROUDON]      = ExpandPlaceholder_Groudon,
+        [PLACEHOLDER_ID_OTHER_RIVAL]  = ExpandPlaceholder_OtherRivalName,
     };
 
     if (id >= ARRAY_COUNT(funcs))


### PR DESCRIPTION
## Summary
- add OTHER_RIVAL placeholder for referencing both rivals by name
- expand placeholder logic so second rival name matches chosen gender
- update rival house intro text to mention both rivals
- expand rival house intro with player reaction, broadcast, and invitation

## Testing
- `make check` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b8e19e8208323a0363c189378982d