### PR TITLE
Add rival intro and clock call

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -97,3 +97,27 @@ LittlerootTown_PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
         .string "in downstairs, too!\p"
         .string "POKEMON movers are so convenient!$"
         .equ PlayersHouse_2F_Text_HowDoYouLikeYourRoom, LittlerootTown_PlayersHouse_2F_Text_HowDoYouLikeYourRoom
+
+PlayersHouse_2F_Text_RivalWelcomeRoom:
+        .string "{RIVAL}: Here we are! This will be\n"
+        .string "your room while you're staying with\n"
+        .string "us. Everything's neat and ready for\n"
+        .string "you. I even made sure your bed was\n"
+        .string "comfy!$"
+
+PlayersHouse_2F_Text_PlayerThanks:
+        .string "{PLAYER}: Thanks… it feels nice to\n"
+        .string "have my own space again.$"
+
+PlayersHouse_2F_Text_RivalLeaveClock:
+        .string "{RIVAL}: Alright! Make sure\n"
+        .string "everything's organized and set up the\n"
+        .string "clock. I'll be downstairs if you\n"
+        .string "need me.$"
+
+PlayersHouse_2F_Text_RivalCallsDownstairs:
+        .string "{RIVAL}: {PLAYER}! Quick, come\n"
+        .string "downstairs! You have to see this!$"
+
+PlayersHouse_2F_Text_PlayerWonder:
+        .string "{PLAYER}: I wonder what that could be.$"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -1,6 +1,9 @@
 PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet::
-	setvar VAR_LITTLEROOT_INTRO_STATE, 5
-	return
+        setvar VAR_LITTLEROOT_INTRO_STATE, 5
+        msgbox PlayersHouse_2F_Text_RivalWelcomeRoom, MSGBOX_DEFAULT
+        msgbox PlayersHouse_2F_Text_PlayerThanks, MSGBOX_DEFAULT
+        msgbox PlayersHouse_2F_Text_RivalLeaveClock, MSGBOX_DEFAULT
+        return
 
 PlayersHouse_1F_EventScript_EnterHouseMovingIn::
 	msgbox PlayersHouse_1F_Text_IsntItNiceInHere, MSGBOX_DEFAULT
@@ -61,13 +64,12 @@ PlayersHouse_2F_EventScript_WallClock::
 	setflag FLAG_SET_WALL_CLOCK
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_1
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_2
-	checkplayergender
-	call_if_eq VAR_RESULT, MALE, PlayersHouse_2F_EventScript_MomComesUpstairsMale
-	call_if_eq VAR_RESULT, FEMALE, PlayersHouse_2F_EventScript_MomComesUpstairsFemale
-	playse SE_EXIT
-	removeobject VAR_0x8008
-	releaseall
-	end
+        msgbox PlayersHouse_2F_Text_RivalCallsDownstairs, MSGBOX_DEFAULT
+        msgbox PlayersHouse_2F_Text_PlayerWonder, MSGBOX_DEFAULT
+        warp MAP_LITTLEROOT_TOWN_PLAYERS_HOUSE_1F, 8, 2
+        waitstate
+        releaseall
+        end
 
 PlayersHouse_2F_EventScript_MomComesUpstairsMale::
 	setvar VAR_0x8008, LOCALID_PLAYERS_HOUSE_2F_MOM


### PR DESCRIPTION
## Summary
- Add in-room rival introduction sequence for the player's temporary room
- Trigger rival's call and warp downstairs after setting the clock

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bc010b0e88323badc1c3ca286c097