### PR TITLE
Add script command for setting object graphics

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -669,15 +669,22 @@
 		.endif
 	.endm
 
-	@ Sets the specified (localId) object's position on the current map.
-	.macro setobjectxy localId:req, x:req, y:req
-	.byte SCR_OP_SETOBJECTXY
-	.2byte \localId
-	.2byte \x
-	.2byte \y
-	.endm
+        @ Sets the specified (localId) object's position on the current map.
+        .macro setobjectxy localId:req, x:req, y:req
+        .byte SCR_OP_SETOBJECTXY
+        .2byte \localId
+        .2byte \x
+        .2byte \y
+        .endm
 
-	@ Sets the specified object's invisibility to FALSE.
+        @ Sets the specified object's graphics id.
+        .macro setobjectgfxid localId:req, graphicsId:req
+        .byte SCR_OP_SETOBJECTGFXID
+        .2byte \localId
+        .2byte \graphicsId
+        .endm
+
+        @ Sets the specified object's invisibility to FALSE.
 	.macro showobjectat localId:req, map:req
 	.byte SCR_OP_SHOWOBJECTAT
 	.2byte \localId

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -256,8 +256,9 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_DYNMULTIPUSH                  ScrCmd_dynmultipush,                requests_effects=1  @ 0xe4
     script_cmd_table_entry SCR_OP_QUESTMENU                     ScrCmd_questmenu,                   requests_effects=1  @ 0xe5
     script_cmd_table_entry SCR_OP_RETURNQUESTSTATE              ScrCmd_returnqueststate,            requests_effects=1  @ 0xe6
-    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7	
-		.if ALLOCATE_SCRIPT_CMD_TABLE
+    script_cmd_table_entry SCR_OP_SUBQUESTMENU                  ScrCmd_subquestmenu,                requests_effects=1  @ 0xe7
+    script_cmd_table_entry SCR_OP_SETOBJECTGFXID                ScrCmd_setobjectgfxid,              requests_effects=1  @ 0xe8
+                .if ALLOCATE_SCRIPT_CMD_TABLE
 gScriptCmdTableEnd::
         .4byte ScrCmd_nop
         .endif

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1458,6 +1458,17 @@ bool8 ScrCmd_copyobjectxytoperm(struct ScriptContext *ctx)
     return FALSE;
 }
 
+bool8 ScrCmd_setobjectgfxid(struct ScriptContext *ctx)
+{
+    u16 localId = VarGet(ScriptReadHalfword(ctx));
+    u16 graphicsId = VarGet(ScriptReadHalfword(ctx));
+
+    Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
+
+    ObjectEventSetGraphicsIdByLocalIdAndMap(localId, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, graphicsId);
+    return FALSE;
+}
+
 bool8 ScrCmd_showobjectat(struct ScriptContext *ctx)
 {
     u16 localId = VarGet(ScriptReadHalfword(ctx));


### PR DESCRIPTION
## Summary
- support `setobjectgfxid` to change overworld NPC sprites dynamically
- hook new command into script command table
- add macro for emitting the new instruction

## Testing
- `make -j4`
- `make -C test` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_688bcbe88d348323bac9b969b24c63bf