### PR TITLE
Fix missing prototype for object graphics update

### DIFF
--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -159,6 +159,7 @@ void CameraObjectReset(void);
 u8 LoadObjectEventPalette(u16);
 u8 UpdateSpritePaletteByTemplate(const struct SpriteTemplate *spriteTemplate, struct Sprite *sprite);
 void ObjectEventSetGraphicsId(struct ObjectEvent *objectEvent, u16 graphicsId);
+void ObjectEventSetGraphicsIdByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup, u16 graphicsId);
 void ObjectEventTurn(struct ObjectEvent *objectEvent, u8 direction);
 void ObjectEventTurnByLocalIdAndMap(u8 localId, u8 mapNum, u8 mapGroup, u8 direction);
 const struct ObjectEventGraphicsInfo *GetObjectEventGraphicsInfo(u16 graphicsId);


### PR DESCRIPTION
## Summary
- declare `ObjectEventSetGraphicsIdByLocalIdAndMap` in `event_object_movement.h` so script command compilation succeeds

## Testing
- `make build/modern/src/scrcmd.o`

------
https://chatgpt.com/codex/tasks/task_e_688bd52fdb2c83239ece8e93c6ca79f1