### PR TITLE
Add rival intro and clock call

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -1,15 +1,19 @@
 .set LOCALID_RIVAL, 1
 
 LittlerootTown_PlayersHouse_2F_MapScripts::
-	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_PlayersHouse_2F_OnTransition
-	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_PlayersHouse_2F_OnWarp
-	.byte 0
+       map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_PlayersHouse_2F_OnTransition
+       map_script MAP_SCRIPT_ON_FRAME_TABLE, LittlerootTown_PlayersHouse_2F_OnFrame
+       map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_PlayersHouse_2F_OnWarp
+       .byte 0
 
 LittlerootTown_PlayersHouse_2F_OnTransition:
-	call_if_eq VAR_INTRO_STATE, 4, PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet
-	call SecretBase_EventScript_SetDecorationFlags
-	setvar VAR_SECRET_BASE_INITIALIZED, 0
-	end
+       call SecretBase_EventScript_SetDecorationFlags
+       setvar VAR_SECRET_BASE_INITIALIZED, 0
+       end
+
+LittlerootTown_PlayersHouse_2F_OnFrame:
+       map_script_2 VAR_INTRO_STATE, 4, PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet
+       .2byte 0
 
 LittlerootTown_PlayersHouse_2F_OnWarp:
 	map_script_2 VAR_SECRET_BASE_INITIALIZED, 0, LittlerootTown_PlayersHouse_2F_EventScript_CheckInitDecor
@@ -97,3 +101,27 @@ LittlerootTown_PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
         .string "in downstairs, too!\p"
         .string "POKEMON movers are so convenient!$"
         .equ PlayersHouse_2F_Text_HowDoYouLikeYourRoom, LittlerootTown_PlayersHouse_2F_Text_HowDoYouLikeYourRoom
+
+PlayersHouse_2F_Text_RivalWelcomeRoom:
+        .string "{RIVAL}: Here we are! This will be\n"
+        .string "your room while you're staying with\n"
+        .string "us. Everything's neat and ready for\n"
+        .string "you. I even made sure your bed was\n"
+        .string "comfy!$"
+
+PlayersHouse_2F_Text_PlayerThanks:
+        .string "{PLAYER}: Thanks… it feels nice to\n"
+        .string "have my own space again.$"
+
+PlayersHouse_2F_Text_RivalLeaveClock:
+        .string "{RIVAL}: Alright! Make sure\n"
+        .string "everything's organized and set up the\n"
+        .string "clock. I'll be downstairs if you\n"
+        .string "need me.$"
+
+PlayersHouse_2F_Text_RivalCallsDownstairs:
+        .string "{RIVAL}: {PLAYER}! Quick, come\n"
+        .string "downstairs! You have to see this!$"
+
+PlayersHouse_2F_Text_PlayerWonder:
+        .string "{PLAYER}: I wonder what that could be.$"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -1,6 +1,11 @@
 PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet::
-	setvar VAR_LITTLEROOT_INTRO_STATE, 5
-	return
+       lockall
+       setvar VAR_LITTLEROOT_INTRO_STATE, 5
+       msgbox PlayersHouse_2F_Text_RivalWelcomeRoom, MSGBOX_DEFAULT
+       msgbox PlayersHouse_2F_Text_PlayerThanks, MSGBOX_DEFAULT
+       msgbox PlayersHouse_2F_Text_RivalLeaveClock, MSGBOX_DEFAULT
+       releaseall
+       return
 
 PlayersHouse_1F_EventScript_EnterHouseMovingIn::
 	msgbox PlayersHouse_1F_Text_IsntItNiceInHere, MSGBOX_DEFAULT
@@ -61,13 +66,12 @@ PlayersHouse_2F_EventScript_WallClock::
 	setflag FLAG_SET_WALL_CLOCK
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_1
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_2
-	checkplayergender
-	call_if_eq VAR_RESULT, MALE, PlayersHouse_2F_EventScript_MomComesUpstairsMale
-	call_if_eq VAR_RESULT, FEMALE, PlayersHouse_2F_EventScript_MomComesUpstairsFemale
-	playse SE_EXIT
-	removeobject VAR_0x8008
-	releaseall
-	end
+        msgbox PlayersHouse_2F_Text_RivalCallsDownstairs, MSGBOX_DEFAULT
+        msgbox PlayersHouse_2F_Text_PlayerWonder, MSGBOX_DEFAULT
+        warp MAP_LITTLEROOT_TOWN_PLAYERS_HOUSE_1F, 8, 2
+        waitstate
+        releaseall
+        end
 
 PlayersHouse_2F_EventScript_MomComesUpstairsMale::
 	setvar VAR_0x8008, LOCALID_PLAYERS_HOUSE_2F_MOM


### PR DESCRIPTION
## Summary
- Run rival's room introduction after fade-in to avoid a black screen when going upstairs
- Wrap rival's dialogue sequence with lock and release for proper control flow

## Testing
- `make test` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bc010b0e88323badc1c3ca286c097