### PR TITLE
Have rival follow after Petalburg Gym report

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -91,7 +91,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_PetalburgGymReport::
         setobjectxy LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
         setobjectmovementtype LOCALID_RIVALS_HOUSE_1F_RIVAL, MOVEMENT_TYPE_FACE_UP
         setvar VAR_0x8004, MALE
-        setvar VAR_0x8005, LOCALID_RIVALS_HOUSE_1F_MOM
+        setvar VAR_0x8005, LOCALID_RIVALS_HOUSE_1F_RIVAL
         goto PlayersHouse_1F_EventScript_PetalburgGymReportMale
         end
 


### PR DESCRIPTION
## Summary
- Make Brendan's rival follow during the Petalburg Gym TV report event

## Testing
- `make -j2`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688be432ee088323bd5189cee2c8710d