### PR TITLE
Fix rival cutscene on Littleroot upstairs

### DIFF
--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -90,7 +90,7 @@ LittlerootTown_MaysHouse_1F_EventScript_PetalburgGymReport::
         setobjectxy LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
         setobjectmovementtype LOCALID_RIVALS_HOUSE_1F_RIVAL, MOVEMENT_TYPE_FACE_UP
         setvar VAR_0x8004, FEMALE
-        setvar VAR_0x8005, LOCALID_RIVALS_HOUSE_1F_MOM
+        setvar VAR_0x8005, LOCALID_RIVALS_HOUSE_1F_RIVAL
         goto PlayersHouse_1F_EventScript_PetalburgGymReportFemale
         end
 
@@ -266,13 +266,12 @@ LittlerootTown_MaysHouse_1F_EventScript_MeetRival::
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_MAY
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_2F_POKE_BALL
 	clearflag FLAG_HIDE_LITTLEROOT_TOWN_MAYS_HOUSE_RIVAL_BEDROOM
-	delay 30
-	setvar VAR_LITTLEROOT_RIVAL_STATE, 3
-	setvar VAR_LITTLEROOT_TOWN_STATE, 1
-	savebgm MUS_DUMMY
-	fadedefaultbgm
-	releaseall
-	end
+        delay 30
+        setvar VAR_LITTLEROOT_TOWN_STATE, 1
+        savebgm MUS_DUMMY
+        fadedefaultbgm
+        releaseall
+        end
 
 LittlerootTown_MaysHouse_1F_EventScript_PlayerFaceMay::
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterDown


### PR DESCRIPTION
## Summary
- Use rival NPC instead of their mom during Petalburg Gym report in rival's house
- Defer rival-state update until after upstairs encounter so the 2F cutscene triggers

## Testing
- `make check` (failed: interrupted building tests)


------
https://chatgpt.com/codex/tasks/task_e_688be30ce6048323ba31f85ef6a2049c