### PR TITLE
feat: add homecoming dialogue

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -303,8 +303,26 @@ PlayersHouse_1F_Text_ArentYouInterestedInRoom:
 	.string "very own room?$"
 
 PlayersHouse_1F_Text_GoSetTheClock:
-	.string "MOM: {PLAYER}.\p"
-	.string "Go set the clock in your room, honey.$"
+        .string "MOM: {PLAYER}.\p"
+        .string "Go set the clock in your room, honey.$"
+
+PlayersHouse_1F_Text_Entrance:
+        .string "MOM: Oh! {PLAYER}! Is it really you...\n"
+        .string "after all these years!?$"
+
+PlayersHouse_1F_Text_PlayerReply:
+        .string "{PLAYER}: Yeah...\n"
+        .string "It feels so nostalgic to be back here.$"
+
+PlayersHouse_1F_Text_MomExcited:
+        .string "MOM: I can't believe how much you've grown!\n"
+        .string "{RIVAL} will be so happy to have their\n"
+        .string "friend back!$"
+
+PlayersHouse_1F_Text_RivalPrompt:
+        .string "{RIVAL}: Heh, I told you Mom would be\n"
+        .string "surprised! Come on, I'll show you your\n"
+        .string "room upstairs!$"
 
 PlayersHouse_1F_Text_OhComeQuickly:
 	.string "MOM: Oh! {PLAYER}, {PLAYER}!\n"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -3,19 +3,24 @@ PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet::
 	return
 
 PlayersHouse_1F_EventScript_EnterHouseMovingIn::
-	msgbox PlayersHouse_1F_Text_IsntItNiceInHere, MSGBOX_DEFAULT
-	applymovement VAR_0x8004, Common_Movement_FacePlayer
-	waitmovement 0
-	call_if_eq VAR_0x8005, MALE, PlayersHouse_1F_EventScript_MomFacePlayerMovingInMale
-	call_if_eq VAR_0x8005, FEMALE, PlayersHouse_1F_EventScript_MomFacePlayerMovingInFemale
-	msgbox PlayersHouse_1F_Text_MoversPokemonGoSetClock, MSGBOX_DEFAULT
-	closemessage
-	setvar VAR_LITTLEROOT_INTRO_STATE, 4
-	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerWalkIn
-	applymovement VAR_0x8004, Common_Movement_WalkInPlaceFasterUp
-	waitmovement 0
-	releaseall
-	end
+        addobject VAR_0x8004
+        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerWalkIn
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_PlayerWalkIn
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_Entrance, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PlayerReply, MSGBOX_DEFAULT
+        call_if_eq VAR_0x8005, MALE, PlayersHouse_1F_EventScript_MomApproachHomecomingMale
+        call_if_eq VAR_0x8005, FEMALE, PlayersHouse_1F_EventScript_MomApproachHomecomingFemale
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_MomExcited, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_RivalPrompt, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_LITTLEROOT_INTRO_STATE, 4
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, LittlerootTown_BrendansHouse_1F_Movement_BrendanGoUpstairs0
+        waitmovement 0
+        releaseall
+        end
 
 PlayersHouse_1F_EventScript_MomFacePlayerMovingInMale::
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
@@ -23,13 +28,41 @@ PlayersHouse_1F_EventScript_MomFacePlayerMovingInMale::
 	return
 
 PlayersHouse_1F_EventScript_MomFacePlayerMovingInFemale::
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	return
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        return
+
+PlayersHouse_1F_EventScript_MomApproachHomecomingMale::
+        applymovement VAR_0x8004, PlayersHouse_1F_Movement_MomApproachHomecomingMale
+        return
+
+PlayersHouse_1F_EventScript_MomApproachHomecomingFemale::
+        applymovement VAR_0x8004, PlayersHouse_1F_Movement_MomApproachHomecomingFemale
+        return
 
 PlayersHouse_1F_Movement_PlayerWalkIn:
-	walk_up
-	step_end
+        walk_up
+        step_end
+
+PlayersHouse_1F_Movement_MomApproachHomecomingMale:
+        walk_down
+        walk_right
+        walk_right
+        walk_right
+        walk_right
+        walk_right
+        walk_right
+        step_end
+
+PlayersHouse_1F_Movement_MomApproachHomecomingFemale:
+        walk_down
+        walk_left
+        walk_left
+        walk_left
+        walk_left
+        walk_left
+        walk_left
+        step_end
 
 PlayersHouse_1F_EventScript_MomGoSeeRoom::
 	msgbox PlayersHouse_1F_Text_ArentYouInterestedInRoom, MSGBOX_DEFAULT


### PR DESCRIPTION
## Summary
- add reunion dialogue for the player's mom and rival
- script event to display new conversation and send rival upstairs
- spawn rival beside the player and have mom walk over for the scene

## Testing
- `apt-get install -y gcc-arm-none-eabi` *(partial: requires 574 MB; not installed)*
- `make tidy` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dc1216e588323a9bf408b1d2ee8e7