### PR TITLE
Call rival downstairs after setting clock

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -90,6 +90,10 @@ PlayersHouse_2F_Text_ItsAGameCube:
         .string "A Game Boy Advance is connected to\n"
         .string "serve as the Controller.$"
 
+PlayersHouse_2F_Text_RivalHurryDownstairs:
+        .string "{RIVAL}: {PLAYER}! Hurry!\n"
+        .string "Come downstairs, quick!$"
+
 LittlerootTown_PlayersHouse_2F_Text_HowDoYouLikeYourRoom:
         .string "MOM: How do you like your room?\p"
         .string "Everything's put away neatly.\n"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -132,21 +132,19 @@ LittlerootTown_MaysHouse_2F_EventScript_WallClock::
 	end
 
 PlayersHouse_2F_EventScript_WallClock::
-	goto_if_set FLAG_SET_WALL_CLOCK, PlayersHouse_2F_EventScript_CheckWallClock
-	msgbox PlayersHouse_2F_Text_ClockIsStopped, MSGBOX_DEFAULT
-	call PlayersHouse_2F_EventScript_SetWallClock
-	delay 30
-	setvar VAR_LITTLEROOT_INTRO_STATE, 6
-	setflag FLAG_SET_WALL_CLOCK
-	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_1
-	setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_2
-	checkplayergender
-	call_if_eq VAR_RESULT, MALE, PlayersHouse_2F_EventScript_MomComesUpstairsMale
-	call_if_eq VAR_RESULT, FEMALE, PlayersHouse_2F_EventScript_MomComesUpstairsFemale
-	playse SE_EXIT
-	removeobject VAR_0x8008
-	releaseall
-	end
+        goto_if_set FLAG_SET_WALL_CLOCK, PlayersHouse_2F_EventScript_CheckWallClock
+        msgbox PlayersHouse_2F_Text_ClockIsStopped, MSGBOX_DEFAULT
+        call PlayersHouse_2F_EventScript_SetWallClock
+        delay 30
+        setvar VAR_LITTLEROOT_INTRO_STATE, 6
+        setflag FLAG_SET_WALL_CLOCK
+        setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_1
+        setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_VIGOROTH_2
+        delay 30
+        playse SE_PIN
+        msgbox PlayersHouse_2F_Text_RivalHurryDownstairs, MSGBOX_DEFAULT
+        releaseall
+        end
 
 PlayersHouse_2F_EventScript_MomComesUpstairsMale::
 	setvar VAR_0x8008, LOCALID_PLAYERS_HOUSE_2F_MOM


### PR DESCRIPTION
## Summary
- Replace mom's upstairs visit with a delay, chime, and message from the rival urging the player downstairs after setting the wall clock
- Add new text for the rival's upstairs call and ensure intro state still triggers the downstairs TV broadcast

## Testing
- `make -j4 test`


------
https://chatgpt.com/codex/tasks/task_e_688e3ea22a748323a28980f2cf873b5f