### PR TITLE
feat: move mom and rival aside during gym report

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -26,7 +26,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_ShowRunningShoesManual::
 LittlerootTown_BrendansHouse_1F_OnTransition:
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToStairs
-        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV
+        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomAndRivalToTV
         end
 
 LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToStairs::
@@ -40,9 +40,16 @@ LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV::
 	return
 
 LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToDoor::
-	setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 9, 8
-	setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
-	return
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 9, 8
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        return
+
+LittlerootTown_BrendansHouse_1F_EventScript_MoveMomAndRivalToTV::
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 4, 5
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        setobjectxyperm LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
+        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        return
 
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 @ The below SS Ticket script uses Mays house state by accident(?), but theyre both set identically after the intro

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -26,7 +26,7 @@ LittlerootTown_MaysHouse_1F_EventScript_ShowRunningShoesManual::
 LittlerootTown_MaysHouse_1F_OnTransition:
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToStairs
-        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV
+        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_MoveMomAndRivalToTV
         end
 
 LittlerootTown_MaysHouse_1F_EventScript_MoveMomToStairs::
@@ -40,9 +40,16 @@ LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV::
 	return
 
 LittlerootTown_MaysHouse_1F_EventScript_MoveMomToDoor::
-	setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 1, 8
-	setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
-	return
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 1, 8
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        return
+
+LittlerootTown_MaysHouse_1F_EventScript_MoveMomAndRivalToTV::
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 6, 5
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        setobjectxyperm LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
+        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        return
 
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 LittlerootTown_MaysHouse_1F_OnFrame:

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -222,10 +222,8 @@ PlayersHouse_1F_EventScript_SetWatchedBroadcast::
 	end
 
 PlayersHouse_1F_EventScript_PetalburgGymReportMale::
-        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
-        call_if_eq VAR_0x8004, MALE, PlayersHouse_1F_EventScript_SetRivalPosMale
-        call_if_eq VAR_0x8004, FEMALE, PlayersHouse_1F_EventScript_SetRivalPosFemale
-        applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterRight
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomStepAsideMale
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalStepAsideMale
         waitmovement 0
         call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
         applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymMale
@@ -250,10 +248,8 @@ PlayersHouse_1F_EventScript_PetalburgGymReportMale::
         end
 
 PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
-        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
-        call_if_eq VAR_0x8004, MALE, PlayersHouse_1F_EventScript_SetRivalPosMale
-        call_if_eq VAR_0x8004, FEMALE, PlayersHouse_1F_EventScript_SetRivalPosFemale
-        applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterLeft
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomStepAsideFemale
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalStepAsideFemale
         waitmovement 0
         call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
         applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale
@@ -374,10 +370,30 @@ PlayersHouse_1F_Movement_MomReturnToSeatMale:
 	step_end
 
 PlayersHouse_1F_Movement_MomReturnToSeatFemale:
-	walk_right
-	walk_down
-	walk_in_place_faster_left
-	step_end
+        walk_right
+        walk_down
+        walk_in_place_faster_left
+        step_end
+
+PlayersHouse_1F_Movement_MomStepAsideMale:
+        walk_right
+        walk_in_place_faster_left
+        step_end
+
+PlayersHouse_1F_Movement_RivalStepAsideMale:
+        walk_right
+        walk_in_place_faster_left
+        step_end
+
+PlayersHouse_1F_Movement_MomStepAsideFemale:
+        walk_left
+        walk_in_place_faster_right
+        step_end
+
+PlayersHouse_1F_Movement_RivalStepAsideFemale:
+        walk_left
+        walk_in_place_faster_right
+        step_end
 
 PlayersHouse_1F_EventScript_Mom::
 	lock


### PR DESCRIPTION
## Summary
- move mom and rival aside before watching Petalburg Gym broadcast
- add step-aside movement sequences for mom and rival
- spawn rival next to mom in front of the TV before the scene starts

## Testing
- `make -j2 check` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e4dd3be10832398ce5686d7cd6cb3