### PR TITLE
feat: reposition mom and rival for TV broadcast

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -26,7 +26,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_ShowRunningShoesManual::
 LittlerootTown_BrendansHouse_1F_OnTransition:
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToStairs
-        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV
+        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_MoveMomAndRivalToTV
         end
 
 LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToStairs::
@@ -40,9 +40,17 @@ LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToTV::
 	return
 
 LittlerootTown_BrendansHouse_1F_EventScript_MoveMomToDoor::
-	setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 9, 8
-	setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
-	return
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 9, 8
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        return
+
+LittlerootTown_BrendansHouse_1F_EventScript_MoveMomAndRivalToTV::
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 6, 6
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_LEFT
+        setobjectxyperm LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
+        setobjectmovementtype LOCALID_RIVALS_HOUSE_1F_RIVAL, MOVEMENT_TYPE_FACE_UP
+        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        return
 
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 @ The below SS Ticket script uses Mays house state by accident(?), but theyre both set identically after the intro

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -26,7 +26,7 @@ LittlerootTown_MaysHouse_1F_EventScript_ShowRunningShoesManual::
 LittlerootTown_MaysHouse_1F_OnTransition:
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV
         call_if_eq VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToStairs
-        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV
+        call_if_eq VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_MoveMomAndRivalToTV
         end
 
 LittlerootTown_MaysHouse_1F_EventScript_MoveMomToStairs::
@@ -40,9 +40,17 @@ LittlerootTown_MaysHouse_1F_EventScript_MoveMomToTV::
 	return
 
 LittlerootTown_MaysHouse_1F_EventScript_MoveMomToDoor::
-	setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 1, 8
-	setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
-	return
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 1, 8
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_UP
+        return
+
+LittlerootTown_MaysHouse_1F_EventScript_MoveMomAndRivalToTV::
+        setobjectxyperm LOCALID_PLAYERS_HOUSE_1F_MOM, 4, 6
+        setobjectmovementtype LOCALID_PLAYERS_HOUSE_1F_MOM, MOVEMENT_TYPE_FACE_RIGHT
+        setobjectxyperm LOCALID_RIVALS_HOUSE_1F_RIVAL, 5, 5
+        setobjectmovementtype LOCALID_RIVALS_HOUSE_1F_RIVAL, MOVEMENT_TYPE_FACE_UP
+        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        return
 
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 LittlerootTown_MaysHouse_1F_OnFrame:

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -222,44 +222,13 @@ PlayersHouse_1F_EventScript_SetWatchedBroadcast::
 	end
 
 PlayersHouse_1F_EventScript_PetalburgGymReportMale::
-        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
-        call_if_eq VAR_0x8004, MALE, PlayersHouse_1F_EventScript_SetRivalPosMale
-        call_if_eq VAR_0x8004, FEMALE, PlayersHouse_1F_EventScript_SetRivalPosFemale
-        applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterRight
-        waitmovement 0
         call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
         applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymMale
         waitmovement 0
         playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
         call PlayersHouse_1F_EventScript_WatchGymBroadcast
-        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerStepBackFromTVMale
         waitmovement 0
-        msgbox PlayersHouse_1F_Text_MomSurprised, MSGBOX_DEFAULT
-        msgbox PlayersHouse_1F_Text_PlayerReaction, MSGBOX_DEFAULT
-        msgbox PlayersHouse_1F_Text_RivalInviteNeighbor, MSGBOX_DEFAULT
-        closemessage
-        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalRunOutside
-        waitmovement 0
-        removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL
-        msgbox PlayersHouse_1F_Text_PlayerThought, MSGBOX_DEFAULT
-        closemessage
-        setvar VAR_TEMP_1, 1
-        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatMale
-        waitmovement 0
-        goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
-        end
-
-PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
-        addobject LOCALID_RIVALS_HOUSE_1F_RIVAL
-        call_if_eq VAR_0x8004, MALE, PlayersHouse_1F_EventScript_SetRivalPosMale
-        call_if_eq VAR_0x8004, FEMALE, PlayersHouse_1F_EventScript_SetRivalPosFemale
-        applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterLeft
-        waitmovement 0
-        call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale
-        waitmovement 0
-        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-        call PlayersHouse_1F_EventScript_WatchGymBroadcast
         applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
         waitmovement 0
         msgbox PlayersHouse_1F_Text_MomSurprised, MSGBOX_DEFAULT
@@ -272,14 +241,35 @@ PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
         msgbox PlayersHouse_1F_Text_PlayerThought, MSGBOX_DEFAULT
         closemessage
         setvar VAR_TEMP_1, 1
-        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatFemale
+        goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
+        end
+
+PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
+        call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale
         waitmovement 0
+        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerStepBackFromTVFemale
+        waitmovement 0
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_MomSurprised, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PlayerReaction, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_RivalInviteNeighbor, MSGBOX_DEFAULT
+        closemessage
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalRunOutside
+        waitmovement 0
+        removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL
+        msgbox PlayersHouse_1F_Text_PlayerThought, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_TEMP_1, 1
         goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
         end
 
 PlayersHouse_1F_EventScript_MomNoticeGymBroadcast::
         playse SE_PIN
-        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, Common_Movement_ExclamationMark
+        applymovement VAR_0x8005, Common_Movement_ExclamationMark
         waitmovement 0
         msgbox PlayersHouse_1F_Text_RivalCallDownstairs, MSGBOX_DEFAULT
         closemessage
@@ -367,17 +357,6 @@ PlayersHouse_1F_Movement_MomMakeRoomToSeeTVFemale:
 	walk_in_place_faster_left
 	step_end
 
-PlayersHouse_1F_Movement_MomReturnToSeatMale:
-	walk_left
-	walk_down
-	walk_in_place_faster_right
-	step_end
-
-PlayersHouse_1F_Movement_MomReturnToSeatFemale:
-	walk_right
-	walk_down
-	walk_in_place_faster_left
-	step_end
 
 PlayersHouse_1F_EventScript_Mom::
 	lock
@@ -489,8 +468,16 @@ PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale:
 	step_end
 
 PlayersHouse_1F_Movement_PlayerMoveToTVFemale:
-	walk_right
-	step_end
+        walk_right
+        step_end
+
+PlayersHouse_1F_Movement_PlayerStepBackFromTVMale:
+        walk_down
+        step_end
+
+PlayersHouse_1F_Movement_PlayerStepBackFromTVFemale:
+        walk_down
+        step_end
 
 PlayersHouse_1F_Movement_MovePlayerAwayFromDoor:
         walk_up


### PR DESCRIPTION
## Summary
- seat mom at table and leave rival in front of TV for Petalburg Gym scene
- let the player step back after the broadcast so the rival can exit
- place mom and rival at their new spots when entering 1F

## Testing
- `make -j2 check` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688e4dd3be10832398ce5686d7cd6cb3