### PR TITLE
Define missing movement scripts for player's house event

### DIFF
--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -305,11 +305,31 @@ PlayersHouse_1F_EventScript_WatchGymBroadcast::
         delay 35
         return
 
+PlayersHouse_1F_Movement_MomStepAsideMale:
+        walk_up
+        walk_in_place_faster_up
+        step_end
+
+PlayersHouse_1F_Movement_RivalStepAsideMale:
+        walk_up
+        walk_in_place_faster_up
+        step_end
+
+PlayersHouse_1F_Movement_MomStepAsideFemale:
+        walk_up
+        walk_in_place_faster_up
+        step_end
+
+PlayersHouse_1F_Movement_RivalStepAsideFemale:
+        walk_up
+        walk_in_place_faster_up
+        step_end
+
 PlayersHouse_1F_Movement_MomApproachDadMale:
-	walk_up
-	walk_right
-	walk_right
-	walk_right
+        walk_up
+        walk_right
+        walk_right
+        walk_right
 	walk_right
 	walk_down
 	walk_in_place_faster_right


### PR DESCRIPTION
## Summary
- Add mom and rival step-aside movement definitions for the Petalburg Gym TV event

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_688ee217d5208323a0189a42c5f5eca2