### PR TITLE
Adjust Petalburg Gym report sequence

### DIFF
--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -223,8 +223,6 @@ PlayersHouse_1F_EventScript_SetWatchedBroadcast::
 
 PlayersHouse_1F_EventScript_PetalburgGymReportMale::
         call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-        setobjectxy VAR_0x8004, 5, 5
-        setobjectxy LOCALID_RIVALS_HOUSE_1F_RIVAL, 6, 5
         applymovement VAR_0x8004, PlayersHouse_1F_Movement_MomStepAsideMale
         applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalStepAsideMale
         waitmovement 0
@@ -241,7 +239,9 @@ PlayersHouse_1F_EventScript_PetalburgGymReportMale::
         call_if_eq VAR_0x8005, MALE, PlayersHouse_1F_EventScript_RivalInviteBrendan
         call_if_eq VAR_0x8005, FEMALE, PlayersHouse_1F_EventScript_RivalInviteMay
         closemessage
-        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalWalkToDoorAndExit
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_MovePlayerAwayFromDoor
+        waitmovement 0
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalWalkToDoorAndExitMale
         waitmovement 0
         removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL
         msgbox PlayersHouse_1F_Text_PlayerThought, MSGBOX_DEFAULT
@@ -252,8 +252,6 @@ PlayersHouse_1F_EventScript_PetalburgGymReportMale::
 
 PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
         call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-        setobjectxy VAR_0x8004, 4, 5
-        setobjectxy LOCALID_RIVALS_HOUSE_1F_RIVAL, 3, 5
         applymovement VAR_0x8004, PlayersHouse_1F_Movement_MomStepAsideFemale
         applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalStepAsideFemale
         waitmovement 0
@@ -270,7 +268,9 @@ PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
         call_if_eq VAR_0x8005, MALE, PlayersHouse_1F_EventScript_RivalInviteBrendan
         call_if_eq VAR_0x8005, FEMALE, PlayersHouse_1F_EventScript_RivalInviteMay
         closemessage
-        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalWalkToDoorAndExit
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_MovePlayerAwayFromDoor
+        waitmovement 0
+        applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalWalkToDoorAndExitFemale
         waitmovement 0
         removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL
         msgbox PlayersHouse_1F_Text_PlayerThought, MSGBOX_DEFAULT
@@ -523,8 +523,23 @@ PlayersHouse_1F_Movement_MovePlayerAwayFromDoor:
         walk_up
         step_end
 
-PlayersHouse_1F_Movement_RivalWalkToDoorAndExit:
-        walk_left
+PlayersHouse_1F_Movement_RivalWalkToDoorAndExitMale:
+        walk_right
+        walk_right
+        walk_down
+        walk_down
+        walk_down
+        walk_down
+        step_end
+
+PlayersHouse_1F_Movement_RivalWalkToDoorAndExitFemale:
+        walk_right
+        walk_right
+        walk_right
+        walk_right
+        walk_right
+        walk_down
+        walk_down
         walk_down
         walk_down
         step_end
@@ -804,8 +819,7 @@ PlayersHouse_1F_Movement_MomLeave:
         step_end
 
 PlayersHouse_1F_Text_RivalCallDownstairs:
-        .string "{RIVAL}: {PLAYER}! Come downstairs!\n"
-        .string "There's something on TV you need to see!$"
+        .string "{RIVAL}: {PLAYER}! Quickly, you have to see this!$"
 
 PlayersHouse_1F_Text_SpaceTimePhenomenon:
         .string "INTERVIEWER: Reports of a space-time\n"


### PR DESCRIPTION
## Summary
- Move player aside before rival exits during Petalburg Gym TV report
- Separate rival exit paths for male and female layouts and tweak announcement text
- Remove unnecessary repositioning of mom and rival so event starts from their existing positions

## Testing
- `make -j4`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688eebb0b76c83239fe8383d80ff6454