### PR TITLE
Fix rival local ID assembler errors

### DIFF
--- a/data/maps/LittlerootTown_PlayersHouse_2F/map.json
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/map.json
@@ -15,7 +15,7 @@
   "connections": 0,
   "object_events": [
     {
-      "local_id": "LOCALID_RIVAL",
+      "local_id": "LOCALID_PLAYERS_HOUSE_2F_RIVAL",
       "graphics_id": "OBJ_EVENT_GFX_VAR_0",
       "x": 7,
       "y": 1,

--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -1,4 +1,4 @@
-.set LOCALID_RIVAL, 1
+
 
 LittlerootTown_PlayersHouse_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_PlayersHouse_2F_OnTransition

--- a/data/maps/NewBarkTown_ProfessorElmsLab/scripts.inc
+++ b/data/maps/NewBarkTown_ProfessorElmsLab/scripts.inc
@@ -1,5 +1,5 @@
 .set LOCALID_ELM, 1
-.set LOCALID_RIVAL, 2
+.set LOCALID_ELMS_LAB_RIVAL, 2
 
 NewBarkTown_ProfessorElmsLab_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, NewBarkTown_ProfessorElmsLab_OnTransition

--- a/data/maps/Route29/scripts.inc
+++ b/data/maps/Route29/scripts.inc
@@ -1,5 +1,5 @@
 .set LOCALID_PROF_ELM, 1
-.set LOCALID_RIVAL, 2
+.set LOCALID_ROUTE29_RIVAL, 2
 
 Route29_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route29_OnTransition
@@ -21,39 +21,39 @@ Route29_EventScript_HideMapNamePopup::
 
 Route29_EventScript_StartElmMeeting_1::
 	lockall
-	setobjectxy LOCALID_PROF_ELM, 63, 11
-	setobjectxy LOCALID_RIVAL, 63, 10
+        setobjectxy LOCALID_PROF_ELM, 63, 11
+        setobjectxy LOCALID_ROUTE29_RIVAL, 63, 10
 	call Route29_EventScript_StartElmMeeting_ApproachPlayer
 
 Route29_EventScript_StartElmMeeting_2::
 	lockall
-	setobjectxy LOCALID_PROF_ELM, 63, 12
-	setobjectxy LOCALID_RIVAL, 63, 11
+        setobjectxy LOCALID_PROF_ELM, 63, 12
+        setobjectxy LOCALID_ROUTE29_RIVAL, 63, 11
 	call Route29_EventScript_StartElmMeeting_ApproachPlayer
 
 Route29_EventScript_StartElmMeeting_3::
 	lockall
-	setobjectxy LOCALID_PROF_ELM, 63, 11
-	setobjectxy LOCALID_RIVAL, 63, 12
+        setobjectxy LOCALID_PROF_ELM, 63, 11
+        setobjectxy LOCALID_ROUTE29_RIVAL, 63, 12
 	call Route29_EventScript_StartElmMeeting_ApproachPlayer
 
 Route29_EventScript_StartElmMeeting_4::
 	lockall
-	setobjectxy LOCALID_PROF_ELM, 63, 12
-	setobjectxy LOCALID_RIVAL, 63, 13
+        setobjectxy LOCALID_PROF_ELM, 63, 12
+        setobjectxy LOCALID_ROUTE29_RIVAL, 63, 13
 	call Route29_EventScript_StartElmMeeting_ApproachPlayer
 
 Route29_EventScript_StartElmMeeting_ApproachPlayer::
-	applymovement LOCALID_PROF_ELM, Route29_Movement_4East
-	applymovement LOCALID_RIVAL, Route29_Movement_4East
+        applymovement LOCALID_PROF_ELM, Route29_Movement_4East
+        applymovement LOCALID_ROUTE29_RIVAL, Route29_Movement_4East
 	waitmovement 0
 	playse SE_PIN
 	applymovement LOCALID_PROF_ELM, Common_Movement_ExclamationMark
 	waitmovement 0
 	applymovement LOCALID_PROF_ELM, Common_Movement_Delay48
 	waitmovement 0
-	applymovement LOCALID_PROF_ELM, Route29_Movement_3East
-	applymovement LOCALID_RIVAL, Route29_Movement_3East
+        applymovement LOCALID_PROF_ELM, Route29_Movement_3East
+        applymovement LOCALID_ROUTE29_RIVAL, Route29_Movement_3East
 	waitmovement 0
 	call Route29_EventScript_GreetElm
 

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -1,15 +1,15 @@
 PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet::
         lockall
-        addobject LOCALID_RIVAL
-        setobjectxy LOCALID_RIVAL, 7, 1
-        applymovement LOCALID_RIVAL, PlayersHouse_2F_Movement_RivalShowRoom
+        addobject LOCALID_PLAYERS_HOUSE_2F_RIVAL
+        setobjectxy LOCALID_PLAYERS_HOUSE_2F_RIVAL, 7, 1
+        applymovement LOCALID_PLAYERS_HOUSE_2F_RIVAL, PlayersHouse_2F_Movement_RivalShowRoom
         waitmovement 0
         msgbox PlayersHouse_2F_Text_RivalShowRoom, MSGBOX_DEFAULT
         msgbox PlayersHouse_2F_Text_PlayerReplyStrange, MSGBOX_DEFAULT
         msgbox PlayersHouse_2F_Text_RivalReminderClock, MSGBOX_DEFAULT
-        applymovement LOCALID_RIVAL, PlayersHouse_2F_Movement_RivalExit
+        applymovement LOCALID_PLAYERS_HOUSE_2F_RIVAL, PlayersHouse_2F_Movement_RivalExit
         waitmovement 0
-        removeobject LOCALID_RIVAL
+        removeobject LOCALID_PLAYERS_HOUSE_2F_RIVAL
         setvar VAR_LITTLEROOT_INTRO_STATE, 5
         releaseall
         return


### PR DESCRIPTION
## Summary
- Rename rival local IDs in map scripts to unique names
- Remove redundant Player's House rival ID definition and use map-defined constant
- Ensure Route 29 and Elm's Lab scripts reference new rival IDs

## Testing
- `make build/modern/data/event_scripts.o -j4`

------
https://chatgpt.com/codex/tasks/task_e_688f96b89e7083239c2bf6578abd94e4