### PR TITLE
Add clock reminder before leaving player's room

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -56,28 +56,12 @@ LittlerootTown_BrendansHouse_1F_EventScript_SetupGymReport::
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 @ The below SS Ticket script uses Mays house state by accident(?), but theyre both set identically after the intro
 LittlerootTown_BrendansHouse_1F_OnFrame:
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_BrendansHouse_1F_EventScript_EnterHouseMovingIn
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_BrendansHouse_1F_EventScript_GoUpstairsToSetClock
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_PetalburgGymReport
-	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 1, LittlerootTown_BrendansHouse_1F_EventScript_YoureNewNeighbor
-	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
-	.2byte 0
+        map_script_2 VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_BrendansHouse_1F_EventScript_EnterHouseMovingIn
+        map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_PetalburgGymReport
+        map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 1, LittlerootTown_BrendansHouse_1F_EventScript_YoureNewNeighbor
+        map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
+        .2byte 0
 
-LittlerootTown_BrendansHouse_1F_EventScript_GoUpstairsToSetClock::
-	lockall
-	msgbox PlayersHouse_1F_Text_GoSetTheClock, MSGBOX_DEFAULT
-	closemessage
-	applymovement LOCALID_PLAYER, LittlerootTown_BrendansHouse_1F_Movement_PushTowardStairs
-	applymovement LOCALID_PLAYERS_HOUSE_1F_MOM, LittlerootTown_BrendansHouse_1F_Movement_PushTowardStairs
-	waitmovement 0
-	warp MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_2F, 7, 1
-	waitstate
-	releaseall
-	end
-
-LittlerootTown_BrendansHouse_1F_Movement_PushTowardStairs:
-	walk_up
-	step_end
 
 LittlerootTown_BrendansHouse_1F_EventScript_EnterHouseMovingIn::
 	lockall

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -55,28 +55,12 @@ LittlerootTown_MaysHouse_1F_EventScript_SetupGymReport::
 
 @ Many of the below scripts have no gender check because they assume youre in the correct house
 LittlerootTown_MaysHouse_1F_OnFrame:
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_MaysHouse_1F_EventScript_EnterHouseMovingIn
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 5, LittlerootTown_MaysHouse_1F_EventScript_GoUpstairsToSetClock
-	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_PetalburgGymReport
-	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 1, LittlerootTown_MaysHouse_1F_EventScript_YoureNewNeighbor
-	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
-	.2byte 0
+        map_script_2 VAR_LITTLEROOT_INTRO_STATE, 3, LittlerootTown_MaysHouse_1F_EventScript_EnterHouseMovingIn
+        map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_PetalburgGymReport
+        map_script_2 VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 1, LittlerootTown_MaysHouse_1F_EventScript_YoureNewNeighbor
+        map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
+        .2byte 0
 
-LittlerootTown_MaysHouse_1F_EventScript_GoUpstairsToSetClock::
-	lockall
-	msgbox PlayersHouse_1F_Text_GoSetTheClock, MSGBOX_DEFAULT
-	closemessage
-	applymovement LOCALID_PLAYER, LittlerootTown_MaysHouse_1F_Movement_PushTowardStairs
-	applymovement LOCALID_PLAYERS_HOUSE_1F_MOM, LittlerootTown_MaysHouse_1F_Movement_PushTowardStairs
-	waitmovement 0
-	warp MAP_LITTLEROOT_TOWN_MAYS_HOUSE_2F, 1, 1
-	waitstate
-	releaseall
-	end
-
-LittlerootTown_MaysHouse_1F_Movement_PushTowardStairs:
-	walk_up
-	step_end
 
 LittlerootTown_MaysHouse_1F_EventScript_EnterHouseMovingIn::
 	lockall

--- a/data/maps/LittlerootTown_PlayersHouse_2F/map.json
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/map.json
@@ -208,7 +208,15 @@
     }
   ],
   "coord_events": [
-
+    {
+      "type": "trigger",
+      "x": 7,
+      "y": 1,
+      "elevation": 0,
+      "var": "VAR_LITTLEROOT_INTRO_STATE",
+      "var_value": "5",
+      "script": "PlayersHouse_2F_EventScript_RemindSetClock"
+    }
   ],
   "bg_events": [
     {

--- a/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_2F/scripts.inc
@@ -108,6 +108,9 @@ PlayersHouse_2F_Text_RivalReminderClock:
         .string "{RIVAL}: Haha, well, get settled!\n"
         .string "Oh, don't forget to set your clock!$"
 
+PlayersHouse_2F_Text_PlayerForgetClock:
+        .string "Aren't I forgetting something?$"
+
 PlayersHouse_2F_Text_RivalHurryDownstairs:
         .string "{RIVAL}: {PLAYER}! Hurry!\n"
         .string "Come downstairs, quick!$"

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -2,6 +2,16 @@ PlayersHouse_2F_EventScript_BlockStairsUntilClockIsSet::
         setvar VAR_LITTLEROOT_INTRO_STATE, 5
         return
 
+PlayersHouse_2F_EventScript_RemindSetClock::
+        lockall
+        applymovement LOCALID_PLAYER, Common_Movement_WalkDown
+        waitmovement 0
+        msgbox PlayersHouse_2F_Text_PlayerForgetClock, MSGBOX_DEFAULT
+        applymovement LOCALID_PLAYER, PlayersHouse_2F_Movement_PlayerReturnToClock
+        waitmovement 0
+        releaseall
+        end
+
 PlayersHouse_2F_EventScript_RivalIntro::
         lockall
         clearflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_RIVAL_BEDROOM
@@ -229,10 +239,16 @@ PlayersHouse_2F_Movement_MomEntersFemale:
 	step_end
 
 PlayersHouse_2F_Movement_MomExitsFemale:
-	walk_left
-	walk_up
-	delay_8
-	step_end
+        walk_left
+        walk_up
+        delay_8
+        step_end
+
+PlayersHouse_2F_Movement_PlayerReturnToClock:
+        walk_left
+        walk_left
+        walk_in_place_faster_up
+        step_end
 
 PlayersHouse_1F_EventScript_SetWatchedBroadcast::
 	setvar VAR_LITTLEROOT_INTRO_STATE, 7


### PR DESCRIPTION
## Summary
- intercept stair warp in player's room to remind setting the clock
- implemented script to walk player back to clock and face it
- removed forced warp upstairs from Brendan/May houses

## Testing
- `make test` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0fb80208323aa781277a823474f