### PR TITLE
Set intro state when entering player's house

### DIFF
--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -47,6 +47,7 @@ PlayersHouse_1F_EventScript_EnterHouseMovingIn::
         msgbox PlayersHouse_1F_Text_RivalPrompt, MSGBOX_DEFAULT
         closemessage
         setvar VAR_LITTLEROOT_INTRO_STATE, 4
+        setvar VAR_INTRO_STATE, 4
         applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalGoUpstairs
         waitmovement 0
         removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL


### PR DESCRIPTION
## Summary
- Update `PlayersHouse_1F_EventScript_EnterHouseMovingIn` to set `VAR_INTRO_STATE` to `4` so the upstairs rival intro can trigger.

## Testing
- `make clean-tools`
- `make tools`
- Attempted `make -j4` (terminated after numerous libpng warnings)


------
https://chatgpt.com/codex/tasks/task_e_688fc46ab9d883239ad8b23dd413e432