### PR TITLE
Fix rival intro in Littleroot player house

### DIFF
--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -26,6 +26,7 @@ PlayersHouse_2F_EventScript_RivalIntro::
         waitmovement 0
         setflag FLAG_HIDE_LITTLEROOT_TOWN_PLAYERS_HOUSE_RIVAL_BEDROOM
         removeobject LOCALID_RIVAL
+        setvar VAR_LITTLEROOT_INTRO_STATE, 5
         setvar VAR_INTRO_STATE, 5
         releaseall
         return
@@ -47,6 +48,7 @@ PlayersHouse_1F_EventScript_EnterHouseMovingIn::
         msgbox PlayersHouse_1F_Text_RivalPrompt, MSGBOX_DEFAULT
         closemessage
         setvar VAR_LITTLEROOT_INTRO_STATE, 4
+        setvar VAR_INTRO_STATE, 4
         applymovement LOCALID_RIVALS_HOUSE_1F_RIVAL, PlayersHouse_1F_Movement_RivalGoUpstairs
         waitmovement 0
         removeobject LOCALID_RIVALS_HOUSE_1F_RIVAL


### PR DESCRIPTION
## Summary
- Revert unintended changes to other regions' player houses
- Ensure the Littleroot rival introduction sets both global and local intro states

## Testing
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_688fd0dde08483238744f3cebb2ef9d2