### PR TITLE
Randomize switch-in speed ties

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -326,6 +326,7 @@ bool32 IsPartnerMonFromSameTrainer(u32 battler);
 enum ItemEffect TryHandleSeed(u32 battler, u32 terrainFlag, u32 statId, u32 itemId, enum ItemCaseId caseID);
 bool32 IsBattlerAffectedByHazards(u32 battler, bool32 toxicSpikes);
 void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast);
+void SortBattlersBySpeedRandomized(u8 *battlers, bool32 slowToFast);
 bool32 CompareStat(u32 battler, u8 statId, u8 cmpTo, u8 cmpKind);
 bool32 TryRoomService(u32 battler);
 void BufferStatChange(u32 battler, u8 statId, enum StringID stringId);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7804,7 +7804,7 @@ static void Cmd_switchineffects(void)
         case 0: // Sort battlers by speed
             for (i = 0; i < gBattlersCount; i++)
                 gBattleStruct->multipleSwitchInSortedBattlers[i] = i;
-            SortBattlersBySpeed(gBattleStruct->multipleSwitchInSortedBattlers, FALSE);
+            SortBattlersBySpeedRandomized(gBattleStruct->multipleSwitchInSortedBattlers, FALSE);
             gBattleStruct->multipleSwitchInState++;
             gBattleStruct->multipleSwitchInCursor = 0;
             // Loop through all available battlers

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10833,6 +10833,38 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
     }
 }
 
+// Sort battlers by Speed and randomize ties
+// Useful when multiple battlers act within the same priority tier
+void SortBattlersBySpeedRandomized(u8 *battlers, bool32 slowToFast)
+{
+    int i, j, start, end;
+
+    // First, obtain base ordering by Speed
+    SortBattlersBySpeed(battlers, slowToFast);
+
+    // Identify contiguous groups of identical Speed and shuffle each group
+    for (i = 0; i < gBattlersCount; i = end)
+    {
+        u16 speed = GetBattlerTotalSpeedStat(battlers[i]);
+
+        // Determine the range of battlers that share this Speed
+        for (end = i + 1; end < gBattlersCount; end++)
+        {
+            if (GetBattlerTotalSpeedStat(battlers[end]) != speed)
+                break;
+        }
+
+        // Fisher–Yates shuffle within [i, end)
+        for (j = end - 1; j > i; j--)
+        {
+            int r = i + RandomUniform(RNG_SPEED_TIE, 0, j - i);
+            u8 tmp = battlers[j];
+            battlers[j] = battlers[r];
+            battlers[r] = tmp;
+        }
+    }
+}
+
 void TryRestoreHeldItems(void)
 {
     u32 i;
@@ -11700,7 +11732,7 @@ bool32 TrySwitchInEjectPack(enum ItemCaseId caseID)
 
     u8 battlers[4] = {0, 1, 2, 3};
     if (numEjectPackBattlers > 1)
-        SortBattlersBySpeed(battlers, FALSE);
+        SortBattlersBySpeedRandomized(battlers, FALSE);
 
     for (u32 i = 0; i < gBattlersCount; i++)
         gProtectStructs[i].tryEjectPack = FALSE;

--- a/test/battle/switch_in_abilities.c
+++ b/test/battle/switch_in_abilities.c
@@ -106,7 +106,7 @@ DOUBLE_BATTLE_TEST("Switch-in abilities trigger in Speed Order after post-KO swi
     } WHEN {
         TURN { MOVE(playerLeft, MOVE_EXPLOSION); SEND_OUT(playerLeft, 2); SEND_OUT(opponentLeft, 2); SEND_OUT(playerRight, 3); SEND_OUT(opponentRight, 3); }
         TURN { ; }
-    } SCENE {
+} SCENE {
         MESSAGE("Wobbuffet used Explosion!");
         if (spdPlayer1 == 5) {
             ABILITY_POPUP(playerLeft, ABILITY_SAND_STREAM);
@@ -124,5 +124,33 @@ DOUBLE_BATTLE_TEST("Switch-in abilities trigger in Speed Order after post-KO swi
             ABILITY_POPUP(playerRight, ABILITY_INTIMIDATE);
             ABILITY_POPUP(opponentRight, ABILITY_SNOW_WARNING);
         }
+    }
+}
+
+SINGLE_BATTLE_TEST("Switch-in ability order is randomized on Speed ties (Intimidate first)")
+{
+    PASSES_RANDOMLY(1, 2, RNG_SPEED_TIE);
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(5); Ability(ABILITY_INTIMIDATE); }
+        OPPONENT(SPECIES_NINETALES) { Speed(5); Ability(ABILITY_DROUGHT); }
+    } WHEN {
+        TURN { ; }
+    } SCENE {
+        ABILITY_POPUP(player, ABILITY_INTIMIDATE);
+        ABILITY_POPUP(opponent, ABILITY_DROUGHT);
+    }
+}
+
+SINGLE_BATTLE_TEST("Switch-in ability order is randomized on Speed ties (Drought first)")
+{
+    PASSES_RANDOMLY(1, 2, RNG_SPEED_TIE);
+    GIVEN {
+        PLAYER(SPECIES_EKANS) { Speed(5); Ability(ABILITY_INTIMIDATE); }
+        OPPONENT(SPECIES_NINETALES) { Speed(5); Ability(ABILITY_DROUGHT); }
+    } WHEN {
+        TURN { ; }
+    } SCENE {
+        ABILITY_POPUP(opponent, ABILITY_DROUGHT);
+        ABILITY_POPUP(player, ABILITY_INTIMIDATE);
     }
 }


### PR DESCRIPTION
## Summary
- shuffle battler arrays sharing equal Speed with new `SortBattlersBySpeedRandomized`
- use randomized sorting for simultaneous switch-in tiers and Eject Pack handling
- test switch-in ability order randomization under Speed ties

## Testing
- `make check` *(fails: interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_689127146d7c83239c77c7ccf4e8fb47