### PR TITLE
Refactor switch-in event handling

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -500,21 +500,18 @@
 	.4byte \failInstr
 	.endm
 
-	.macro switchhandleorder battler:req, state:req
-	.byte 0x51
-	.byte \battler
-	.byte \state
-	.endm
+        .macro switchhandleorder battler:req, state:req
+        .byte 0x51
+        .byte \battler
+        .byte \state
+        .endm
 
-	.macro switchineffects battler:req
-	.byte 0x52
-	.byte \battler
-	.endm
+        // 0x52 formerly switchineffects (unused)
 
-	.macro trainerslidein position:req
-	.byte 0x53
-	.byte \position
-	.endm
+        .macro trainerslidein position:req
+        .byte 0x53
+        .byte \position
+        .endm
 
 	.macro playse song:req
 	.byte 0x54

--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -318,7 +318,6 @@ BattleScript_MoveSwitchOpenPartyScreen::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, FALSE, TRUE
 	waitstate
-	switchineffects BS_ATTACKER
 BattleScript_MoveSwitchEnd:
 	end
 
@@ -465,7 +464,6 @@ BattleScript_EffectRevivalBlessingSendOut:
 	hpthresholds BS_SCRIPTING
 	switchinanim BS_SCRIPTING, FALSE, FALSE
 	waitstate
-	switchineffects BS_SCRIPTING
 	goto BattleScript_MoveEnd
 
 BattleScript_StealthRockActivates::
@@ -2288,7 +2286,6 @@ BattleScript_EffectHealingWish::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, FALSE, TRUE
 	waitstate
-	switchineffects BS_ATTACKER
 .endif
 BattleScript_EffectHealingWishEnd:
 	moveendall
@@ -4096,7 +4093,6 @@ BattleScript_EffectBatonPass::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, FALSE, TRUE
 	waitstate
-	switchineffects BS_ATTACKER
 	goto BattleScript_MoveEnd
 
 BattleScript_EffectMorningSun::
@@ -5166,14 +5162,12 @@ BattleScript_FaintedMonSendOutNew:
 	trytrainerslidemsglaston BS_FAINTED
 	jumpifbytenotequal sSHIFT_SWITCHED, sZero, BattleScript_FaintedMonShiftSwitched
 BattleScript_FaintedMonSendOutNewEnd:
-	switchineffects BS_FAINTED
 	jumpifbattletype BATTLE_TYPE_DOUBLE, BattleScript_FaintedMonEnd
 	cancelallactions
 BattleScript_FaintedMonEnd::
 	end2
 BattleScript_FaintedMonShiftSwitched:
 	copybyte sSAVED_BATTLER, gBattlerTarget
-	switchineffects BS_ATTACKER
 	resetsentmonsvalue
 	copybyte gBattlerTarget, sSAVED_BATTLER
 	goto BattleScript_FaintedMonSendOutNewEnd
@@ -5196,10 +5190,8 @@ BattleScript_HandleFaintedMonLoop::
 	hidepartystatussummary BS_FAINTED
 	switchinanim BS_FAINTED, FALSE, FALSE
 	waitstate
-	switchineffects BS_FAINTED_MULTIPLE_1
 	jumpifbytenotequal gBattlerFainted, gBattlersCount, BattleScript_HandleFaintedMonLoop
 BattleScript_HandleFaintedMonMultipleEnd::
-	switchineffects BS_FAINTED_MULTIPLE_2
 	end2
 
 BattleScript_LocalTrainerBattleWon::
@@ -5412,7 +5404,6 @@ BattleScript_DoSwitchOut::
 	hidepartystatussummary BS_ATTACKER
 	switchinanim BS_ATTACKER, FALSE, FALSE
 	waitstate
-	switchineffects BS_ATTACKER
 	moveendcase MOVEEND_STATUS_IMMUNITY_ABILITIES
 	moveendcase MOVEEND_MIRROR_MOVE
 	end2
@@ -5676,7 +5667,6 @@ BattleScript_RoarSuccessSwitch::
 	switchinanim BS_TARGET, FALSE, FALSE
 	waitstate
 	printstring STRINGID_PKMNWASDRAGGEDOUT
-	switchineffects BS_TARGET
 	jumpifbyte CMP_EQUAL, sSWITCH_CASE, B_SWITCH_RED_CARD, BattleScript_RoarSuccessSwitch_Ret
 	setbyte sSWITCH_CASE, B_SWITCH_NORMAL
 	goto BattleScript_MoveEnd
@@ -7203,7 +7193,6 @@ BattleScript_EmergencyExit::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_SCRIPTING, FALSE, TRUE
 	waitstate
-	switchineffects BS_SCRIPTING
 BattleScript_EmergencyExitRet:
 	return
 
@@ -7236,7 +7225,6 @@ BattleScript_EmergencyExitEnd2::
 	printstring STRINGID_SWITCHINMON
 	switchinanim BS_ATTACKER, FALSE, TRUE
 	waitstate
-	switchineffects BS_ATTACKER
 BattleScript_EmergencyExitRetEnd2:
 	end2
 
@@ -9139,7 +9127,6 @@ BattleScript_EjectButtonActivates::
 	printstring 0x3
 	switchinanim BS_SCRIPTING, FALSE, TRUE
 	waitstate
-	switchineffects BS_SCRIPTING
 BattleScript_EjectButtonEnd:
 	return
 

--- a/data/battle_scripts_2.s
+++ b/data/battle_scripts_2.s
@@ -77,7 +77,6 @@ BattleScript_ItemRestoreHP_Party::
 BattleScript_ItemRestoreHP_SendOutRevivedBattler:
 	switchinanim BS_SCRIPTING, FALSE, FALSE
 	waitstate
-	switchineffects BS_SCRIPTING
 	end
 
 BattleScript_ItemCureStatus::

--- a/include/battle.h
+++ b/include/battle.h
@@ -193,7 +193,7 @@ struct SpecialStatus
     u8 switchInItemDone:1;
     u8 instructedChosenTarget:3;
     u8 berryReduced:1;
-    u8 announceNeutralizingGas:1;   // See Cmd_switchineffects
+    u8 announceNeutralizingGas:1;
     u8 neutralizingGasRemoved:1;    // See VARIOUS_TRY_END_NEUTRALIZING_GAS
     // End of byte
     u8 gemParam;
@@ -672,6 +672,8 @@ struct BattleStruct
     u16 choicedMove[MAX_BATTLERS_COUNT];
     u16 changedItems[MAX_BATTLERS_COUNT];
     u8 switchInBattlerCounter;
+    u8 switchInEffectsBattler;
+    bool8 switchInEffects;
     u8 arenaTurnCounter;
     u8 turnSideTracker;
     u16 lastTakenMoveFrom[MAX_BATTLERS_COUNT][MAX_BATTLERS_COUNT]; // a 2-D array [target][attacker]


### PR DESCRIPTION
## Summary
- replace `switchineffects` battle script command with automated switch-in handling
- centralize switch-in effect processing in `waitstate`
- streamline battle scripts to invoke universal switch-in events

## Testing
- `make -j4`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68912c5a5264832380568c4b602b49a4