### PR TITLE
Fix UpdateSentMonFlags prototype and remove unused variable

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -349,6 +349,7 @@ static void AccuracyCheck(bool32 recalcDragonDarts, const u8 *nextInstr, const u
 static void ResetValuesForCalledMove(void);
 static void TryRestoreDamageAfterCheekPouch(u32 battler);
 static bool32 TrySymbiosis(u32 battler, u32 itemId, bool32 moveEnd);
+static void UpdateSentMonFlags(u32 battler);
 
 static void Cmd_attackcanceler(void);
 static void Cmd_accuracycheck(void);

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10848,7 +10848,7 @@ void SortBattlersBySpeed(u8 *battlers, bool32 slowToFast)
 // Useful when multiple battlers act within the same priority tier
 void SortBattlersBySpeedRandomized(u8 *battlers, bool32 slowToFast)
 {
-    int i, j, start, end;
+    int i, j, end;
 
     // First, obtain base ordering by Speed
     SortBattlersBySpeed(battlers, slowToFast);


### PR DESCRIPTION
## Summary
- declare `UpdateSentMonFlags` before use to fix implicit declaration
- remove unused `start` variable in `SortBattlersBySpeedRandomized`

## Testing
- `make -B build/modern/src/battle_script_commands.o build/modern/src/battle_util.o`

------
https://chatgpt.com/codex/tasks/task_e_689151e837308323890528a10c8abbb7