### PR TITLE
Remove unused Trainer Hill and Frontier references

### DIFF
--- a/include/constants/trainers.h
+++ b/include/constants/trainers.h
@@ -2,7 +2,8 @@
 #define GUARD_TRAINERS_H
 
 #include "constants/opponents.h"
-#include "constants/battle_frontier_trainers.h"
+// Battle Frontier trainers were removed; provide a stub count
+#define FRONTIER_TRAINERS_COUNT 0
 
 // Special Trainer Ids.
 //      0-299 are frontier trainers

--- a/include/global.h
+++ b/include/global.h
@@ -17,7 +17,6 @@
 #include "constants/maps.h"
 #include "constants/pokemon.h"
 #include "constants/easy_chat.h"
-#include "constants/trainer_hill.h"
 #include "constants/items.h"
 #include "constants/quests.h"
 #include "config/save.h"

--- a/include/trainer_hill.h
+++ b/include/trainer_hill.h
@@ -3,6 +3,44 @@
 
 #define DUMMY_HILL_MON { .nickname = __("$$$$$$$$$$$") }
 
+// Trainer Hill has been removed. Provide stub values so code referencing
+// these macros can still compile without the original constants.
+#ifndef HILL_FLOOR_WIDTH
+#define HILL_FLOOR_WIDTH 1
+#endif
+
+#ifndef HILL_FLOOR_HEIGHT_MAIN
+#define HILL_FLOOR_HEIGHT_MAIN 1
+#endif
+
+#ifndef HILL_TRAINERS_PER_FLOOR
+#define HILL_TRAINERS_PER_FLOOR 1
+#endif
+
+#ifndef NUM_TRAINER_HILL_TRAINERS
+#define NUM_TRAINER_HILL_TRAINERS 0
+#endif
+
+#ifndef NUM_TRAINER_HILL_FLOORS
+#define NUM_TRAINER_HILL_FLOORS 0
+#endif
+
+#ifndef NUM_TRAINER_HILL_MODES
+#define NUM_TRAINER_HILL_MODES 1
+#endif
+
+#ifndef NUM_TRAINER_HILL_TRAINERS_JP
+#define NUM_TRAINER_HILL_TRAINERS_JP 0
+#endif
+
+#ifndef NUM_TRAINER_HILL_FLOORS_JP
+#define NUM_TRAINER_HILL_FLOORS_JP 0
+#endif
+
+#ifndef TRAINER_HILL_OTID
+#define TRAINER_HILL_OTID 0
+#endif
+
 struct TrainerHillTrainer
 {
     u8 name[TRAINER_NAME_LENGTH + 1];

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -32,7 +32,6 @@
 #include "constants/opponents.h"
 #include "constants/species.h"
 #include "constants/trainers.h"
-#include "constants/trainer_hill.h"
 #include "constants/weather.h"
 
 struct BattleWindowText

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -49,7 +49,6 @@
 #include "constants/items.h"
 #include "constants/songs.h"
 #include "constants/trainers.h"
-#include "constants/trainer_hill.h"
 #include "constants/weather.h"
 #include "wild_encounter.h"
 

--- a/src/data/battle_frontier/battle_frontier_trainers.h
+++ b/src/data/battle_frontier/battle_frontier_trainers.h
@@ -1,3 +1,4 @@
+#if FRONTIER_TRAINERS_COUNT > 0
 const struct BattleFrontierTrainer gBattleFrontierTrainers[FRONTIER_TRAINERS_COUNT] =
 {
     [FRONTIER_TRAINER_BRADY] = {
@@ -2404,3 +2405,4 @@ const struct BattleFrontierTrainer gBattleFrontierTrainers[FRONTIER_TRAINERS_COU
         .monSet = (const u16[]){FRONTIER_MONS_AROMA_LADY_3}
     }
 };
+#endif // FRONTIER_TRAINERS_COUNT > 0

--- a/src/data/battle_frontier/trainer_hill.h
+++ b/src/data/battle_frontier/trainer_hill.h
@@ -1,5 +1,6 @@
 // NOTE: Each of these macros turn data into one byte. Therefore ranges for all arguments is 0-15
 // See struct TrainerHillFloorMap for more info about each
+#if NUM_TRAINER_HILL_FLOORS > 0
 #define COORDS_XY(x,y)      ((y<<4)|(x))
 #define TRAINER_DIRS(a, b)  (((a-1)<<4)|(b-1))
 #define TRAINER_RANGE(a, b) ((a<<4)|(b))
@@ -4819,3 +4820,4 @@ static const struct TrainerHillFloor sFloors_Expert[] = {
 #undef COORDS_XY
 #undef TRAINER_DIRS
 #undef TRAINER_RANGE
+#endif // NUM_TRAINER_HILL_FLOORS > 0

--- a/src/ereader_helpers.c
+++ b/src/ereader_helpers.c
@@ -13,7 +13,6 @@
 #include "constants/trainers.h"
 #include "constants/moves.h"
 #include "constants/items.h"
-#include "constants/trainer_hill.h"
 
 // Save data using TryWriteSpecialSaveSector is allowed to exceed SECTOR_DATA_SIZE (up to the counter field)
 STATIC_ASSERT(sizeof(struct TrainerHillChallenge) <= SECTOR_COUNTER_OFFSET, TrainerHillChallengeFreeSpace);

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -39,7 +39,6 @@
 #include "constants/field_poison.h"
 #include "constants/metatile_behaviors.h"
 #include "constants/songs.h"
-#include "constants/trainer_hill.h"
 
 static EWRAM_DATA u8 sWildEncounterImmunitySteps = 0;
 static EWRAM_DATA u16 sPrevMetatileBehavior = 0;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -75,7 +75,6 @@
 #include "constants/layouts.h"
 #include "constants/region_map_sections.h"
 #include "constants/songs.h"
-#include "constants/trainer_hill.h"
 #include "constants/weather.h"
 
 STATIC_ASSERT((B_FLAG_FOLLOWERS_DISABLED == 0 || OW_FOLLOWERS_ENABLED), FollowersFlagAssignedWithoutEnablingThem);

--- a/src/trainer_slide.c
+++ b/src/trainer_slide.c
@@ -30,7 +30,6 @@
 #include "constants/opponents.h"
 #include "constants/species.h"
 #include "constants/trainers.h"
-#include "constants/trainer_hill.h"
 #include "constants/weather.h"
 #include "trainer_slide.h"
 #include "battle_message.h"


### PR DESCRIPTION
## Summary
- drop includes to removed Trainer Hill constants and Battle Frontier trainer data
- stub out Trainer Hill macros so sources compile without dedicated headers

## Testing
- `make -j4` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6892d56e6f1c8323a9d26f27eccc7865