### PR TITLE
Add Battle Frontier news scene

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -307,24 +307,25 @@ PlayersHouse_1F_Text_GoSetTheClock:
 	.string "Go set the clock in your room, honey.$"
 
 PlayersHouse_1F_Text_OhComeQuickly:
-	.string "MOM: Oh! {PLAYER}, {PLAYER}!\n"
-	.string "Quick! Come quickly!$"
-
-PlayersHouse_1F_Text_MaybeDadWillBeOn:
-	.string "MOM: Look! It's PETALBURG GYM!\n"
-	.string "Maybe DAD will be on!$"
+        .string "MOM: {PLAYER}! Hurry, come watch—there's\n"
+        .string "something strange on the news!$"
 
 PlayersHouse_1F_Text_ItsOverWeMissedHim:
-	.string "MOM: Oh… It's over.\p"
-	.string "I think DAD was on, but we missed him.\n"
-	.string "Too bad.$"
+        .string "…The Battle Frontier… gone?$"
+
+PlayersHouse_1F_Text_PortalToJohtoKanto:
+        .string "MOM: A portal to JOHTO and KANTO?\n"
+        .string "That's incredible… and terrifying.$"
+
+PlayersHouse_1F_Text_GladYoureBack:
+        .string "MOM: …Still, I'm glad you're back.\n"
+        .string "BRENDAN and MAY will be elated when\l"
+        .string "they see you again!$"
 
 PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor:
-	.string "Oh, yes.\n"
-	.string "One of DAD's friends lives in town.\p"
-	.string "PROF. BIRCH is his name.\p"
-	.string "He lives right next door, so you should\n"
-	.string "go over and introduce yourself.$"
+        .string "MOM: Why don't you go say hello?\n"
+        .string "I think MAY's next door—or maybe\l"
+        .string "BRENDAN's out on ROUTE 103.$"
 
 PlayersHouse_1F_Text_SeeYouHoney:
 	.string "MOM: See you, honey!$"
@@ -365,11 +366,46 @@ PlayersHouse_1F_Text_Vigoroth1:
 	.string "Fugiiiiih!$"
 
 PlayersHouse_1F_Text_Vigoroth2:
-	.string "Huggoh, uggo uggo…$"
+        .string "Huggoh, uggo uggo…$"
 
-PlayersHouse_1F_Text_ReportFromPetalburgGym:
-	.string "INTERVIEWER: …We brought you this\n"
-	.string "report from in front of PETALBURG GYM.$"
+PlayersHouse_1F_Text_BattleFrontierNews1:
+        .string "REPORTER: We interrupt this program\n"
+        .string "to bring you breaking news from the\l"
+        .string "BATTLE FRONTIER…$"
+
+PlayersHouse_1F_Text_BattleFrontierNews2:
+        .string "REPORTER: Early this morning, a massive\n"
+        .string "space-time distortion engulfed the\l"
+        .string "BATTLE FRONTIER complex.$"
+
+PlayersHouse_1F_Text_BattleFrontierNews3:
+        .string "REPORTER: All seven Battle Facilities\n"
+        .string "have vanished without a trace…$"
+
+PlayersHouse_1F_Text_BattleFrontierNews4:
+        .string "REPORTER: …but what's more shocking is\n"
+        .string "what was discovered in its place.$"
+
+PlayersHouse_1F_Text_BattleFrontierNews5:
+        .string "REPORTER: An interregional gate has\n"
+        .string "appeared where the entrance once stood—\l"
+        .string "and it leads to both JOHTO and KANTO.$"
+
+PlayersHouse_1F_Text_BattleFrontierNews6:
+        .string "REPORTER: DEVON CORP. and SILPH CO. have\n"
+        .string "issued a joint statement confirming\l"
+        .string "their efforts to stabilize the anomaly.$"
+
+PlayersHouse_1F_Text_BattleFrontierNews7:
+        .string "REPORTER: Assisting them is COLRESS—\n"
+        .string "the brilliant scientist formerly\l"
+        .string "associated with UNOVA's PLASMA\l"
+        .string "FOUNDATION.$"
+
+PlayersHouse_1F_Text_BattleFrontierNews8:
+        .string "REPORTER: Authorities urge trainers to\n"
+        .string "remain cautious. Access to the gate is\l"
+        .string "currently restricted…$"
 
 PlayersHouse_1F_Text_TheresAMovieOnTV:
 	.string "There is a movie on TV.\p"

--- a/data/maps/LittlerootTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_PlayersHouse_1F/scripts.inc
@@ -91,23 +91,24 @@ LittlerootTown_PlayersHouse_1F_EventScript_PetalburgGymReport::
 	call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
 	applymovement OBJ_EVENT_ID_PLAYER, LittlerootTown_PlayersHouse_1F_Movement_PlayerApproachTVForGym
 	waitmovement 0
-	playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-	msgbox PlayersHouse_1F_Text_MaybeDadWillBeOn, MSGBOX_DEFAULT
-	closemessage
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
-	waitmovement 0
-	applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
-	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
+        waitmovement 0
+        applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
+        waitmovement 0
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PortalToJohtoKanto, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GladYoureBack, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
         msgbox LittlerootTown_PlayersHouse_1F_Text_ThingsMovedOut, MSGBOX_DEFAULT
         msgbox LittlerootTown_PlayersHouse_1F_Text_StartYourAdventure, MSGBOX_DEFAULT
-	givemon SPECIES_PICHU, 3
-	setflag FLAG_SYS_POKEMON_GET
-	bufferleadmonspeciesname STR_VAR_1
-	playfanfare MUS_OBTAIN_ITEM
+        givemon SPECIES_PICHU, 3
+        setflag FLAG_SYS_POKEMON_GET
+        bufferleadmonspeciesname STR_VAR_1
+        playfanfare MUS_OBTAIN_ITEM
         message LittlerootTown_PlayersHouse_1F_Text_PlayerReceivedPichu
 	waitmessage
 	waitfanfare

--- a/data/maps/NewBarkTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/NewBarkTown_PlayersHouse_1F/scripts.inc
@@ -82,26 +82,27 @@ NewBarkTown_PlayersHouse_1F_EventScript_VioletGymReport::
 	setvar VAR_INTRO_STATE, 7
 	applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterRight
 	waitmovement 0
-	call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-	applymovement OBJ_EVENT_ID_PLAYER, NewBarkTown_PlayersHouse_1F_Movement_PlayerApproachTVForGym
-	waitmovement 0
-	playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-	msgbox NewBarkTown_PlayersHouse_1F_Text_MaybeDadWillBeOn, MSGBOX_DEFAULT
-	closemessage
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
-	waitmovement 0
-	applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
-	waitmovement 0
-	call NewBarkTown_PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
-	msgbox NewBarkTown_PlayersHouse_1F_Text_ThingsMovedOut, MSGBOX_DEFAULT
+        call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
+        applymovement OBJ_EVENT_ID_PLAYER, NewBarkTown_PlayersHouse_1F_Movement_PlayerApproachTVForGym
+        waitmovement 0
+        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
+        waitmovement 0
+        applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
+        waitmovement 0
+        call NewBarkTown_PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PortalToJohtoKanto, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GladYoureBack, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
+        msgbox NewBarkTown_PlayersHouse_1F_Text_ThingsMovedOut, MSGBOX_DEFAULT
         msgbox NewBarkTown_PlayersHouse_1F_Text_StartYourAdventure, MSGBOX_DEFAULT
-	givemon SPECIES_PICHU, 3
-	setflag FLAG_SYS_POKEMON_GET
-	bufferleadmonspeciesname STR_VAR_1
-	playfanfare MUS_OBTAIN_ITEM
+        givemon SPECIES_PICHU, 3
+        setflag FLAG_SYS_POKEMON_GET
+        bufferleadmonspeciesname STR_VAR_1
+        playfanfare MUS_OBTAIN_ITEM
         message NewBarkTown_PlayersHouse_1F_Text_PlayerReceivedPichu
 	waitmessage
 	waitfanfare
@@ -110,14 +111,21 @@ NewBarkTown_PlayersHouse_1F_EventScript_VioletGymReport::
 	call NewBarkTown_PlayersHouse_1F_EventScript_MomLeaving
 
 NewBarkTown_PlayersHouse_1F_EventScript_WatchGymBroadcast::
-	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterUp
-	waitmovement 0
-	msgbox NewBarkTown_PlayersHouse_1F_Text_ReportFromPetalburgGym, MSGBOX_DEFAULT
-	fadedefaultbgm
-	special TurnOffTVScreen
-	setflag FLAG_SYS_TV_HOME
-	delay 35
-	return
+        applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterUp
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews1, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews2, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews3, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews4, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews5, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews6, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews7, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews8, MSGBOX_DEFAULT
+        fadedefaultbgm
+        special TurnOffTVScreen
+        setflag FLAG_SYS_TV_HOME
+        delay 35
+        return
 
 NewBarkTown_PlayersHouse_1F_EventScript_NicknameMon::
 	setvar VAR_0x8004, 0
@@ -228,17 +236,9 @@ NewBarkTown_PlayersHouse_1F_Text_TakeCareOfHouse_Away:
         .string "I'm away, okay?\p"
         .string "I'll be thinking of you!$"
 
-NewBarkTown_PlayersHouse_1F_Text_MaybeDadWillBeOn:
-	.string "MOM: Look! It's Violet City Gym!\n"
-	.string "Maybe Dad will be on!$"
-
-NewBarkTown_PlayersHouse_1F_Text_ReportFromPetalburgGym:
-	.string "INTERVIEWER: …We brought you this\n"
-	.string "report from in front of Violet City Gym.$"
-
 NewBarkTown_PlayersHouse_1F_Text_ThingsMovedOut:
-	.string "Well honey, all of your things have been\n"
-	.string "moved in.\p"
+        .string "Well honey, all of your things have been\n"
+        .string "moved in.\p"
 	.string "Are you sure that you're going to be ok\n"
 	.string "living here alone?\p"
 	.string "You're still welcome to continue living\n"

--- a/data/maps/PalletTown_PlayersHouse_1F/scripts.inc
+++ b/data/maps/PalletTown_PlayersHouse_1F/scripts.inc
@@ -87,22 +87,23 @@ PalletTown_PlayersHouse_1F_EventScript_PetalburgGymReport::
 	applymovement OBJ_EVENT_ID_PLAYER, PalletTown_PlayersHouse_1F_Movement_PlayerApproachTVForGym
 	waitmovement 0
 	playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-	msgbox PlayersHouse_1F_Text_MaybeDadWillBeOn, MSGBOX_DEFAULT
-	closemessage
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
-	waitmovement 0
-	applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
-	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTV
+        waitmovement 0
+        applymovement OBJ_EVENT_ID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTV
+        waitmovement 0
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PortalToJohtoKanto, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GladYoureBack, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
         msgbox PalletTown_PlayersHouse_1F_Text_ThingsMovedOut, MSGBOX_DEFAULT
         msgbox PalletTown_PlayersHouse_1F_Text_StartYourAdventure, MSGBOX_DEFAULT
-	givemon SPECIES_PICHU, 3
-	setflag FLAG_SYS_POKEMON_GET
-	bufferleadmonspeciesname STR_VAR_1
-	playfanfare MUS_OBTAIN_ITEM
+        givemon SPECIES_PICHU, 3
+        setflag FLAG_SYS_POKEMON_GET
+        bufferleadmonspeciesname STR_VAR_1
+        playfanfare MUS_OBTAIN_ITEM
         message PalletTown_PlayersHouse_1F_Text_PlayerReceivedPichu
 	waitmessage
 	waitfanfare

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -145,74 +145,81 @@ PlayersHouse_1F_EventScript_SetWatchedBroadcast::
 	end
 
 PlayersHouse_1F_EventScript_PetalburgGymReportMale::
-	applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterRight
-	waitmovement 0
-	call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymMale
-	waitmovement 0
-	playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-	msgbox PlayersHouse_1F_Text_MaybeDadWillBeOn, MSGBOX_DEFAULT
-	closemessage
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTVMale
-	waitmovement 0
-	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVMale
-	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
-	msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
-	closemessage
-	setvar VAR_TEMP_1, 1
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatMale
-	waitmovement 0
-	goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
+        applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterRight
+        waitmovement 0
+        call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymMale
+        waitmovement 0
+        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTVMale
+        waitmovement 0
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVMale
+        waitmovement 0
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PortalToJohtoKanto, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GladYoureBack, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_TEMP_1, 1
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatMale
+        waitmovement 0
+        goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
 	end
 
 PlayersHouse_1F_EventScript_PetalburgGymReportFemale::
 	applymovement VAR_0x8005, Common_Movement_WalkInPlaceFasterLeft
 	waitmovement 0
-	call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
-	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale
-	waitmovement 0
-	playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
-	msgbox PlayersHouse_1F_Text_MaybeDadWillBeOn, MSGBOX_DEFAULT
-	closemessage
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTVFemale
-	waitmovement 0
-	applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVFemale
-	waitmovement 0
-	call PlayersHouse_1F_EventScript_WatchGymBroadcast
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
-	msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
-	closemessage
-	setvar VAR_TEMP_1, 1
-	applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatFemale
-	waitmovement 0
-	goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
+        call PlayersHouse_1F_EventScript_MomNoticeGymBroadcast
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerApproachTVForGymFemale
+        waitmovement 0
+        playbgm MUS_ENCOUNTER_INTERVIEWER, FALSE
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomMakeRoomToSeeTVFemale
+        waitmovement 0
+        applymovement LOCALID_PLAYER, PlayersHouse_1F_Movement_PlayerMoveToTVFemale
+        waitmovement 0
+        call PlayersHouse_1F_EventScript_WatchGymBroadcast
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterRight
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_ItsOverWeMissedHim, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_PortalToJohtoKanto, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GladYoureBack, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor, MSGBOX_DEFAULT
+        closemessage
+        setvar VAR_TEMP_1, 1
+        applymovement VAR_0x8005, PlayersHouse_1F_Movement_MomReturnToSeatFemale
+        waitmovement 0
+        goto PlayersHouse_1F_EventScript_SetWatchedBroadcast
 	end
 
 PlayersHouse_1F_EventScript_MomNoticeGymBroadcast::
 	playse SE_PIN
-	applymovement VAR_0x8005, Common_Movement_ExclamationMark
-	waitmovement 0
-	applymovement VAR_0x8005, Common_Movement_Delay48
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_OhComeQuickly, MSGBOX_DEFAULT
-	closemessage
-	return
+        applymovement VAR_0x8005, Common_Movement_ExclamationMark
+        waitmovement 0
+        applymovement VAR_0x8005, Common_Movement_Delay48
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_OhComeQuickly, MSGBOX_DEFAULT
+        closemessage
+        return
 
 PlayersHouse_1F_EventScript_WatchGymBroadcast::
-	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterUp
-	waitmovement 0
-	msgbox PlayersHouse_1F_Text_ReportFromPetalburgGym, MSGBOX_DEFAULT
-	fadedefaultbgm
-	special TurnOffTVScreen
-	setflag FLAG_SYS_TV_HOME
-	delay 35
-	return
+        applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterUp
+        waitmovement 0
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews1, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews2, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews3, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews4, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews5, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews6, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews7, MSGBOX_DEFAULT
+        msgbox PlayersHouse_1F_Text_BattleFrontierNews8, MSGBOX_DEFAULT
+        fadedefaultbgm
+        special TurnOffTVScreen
+        setflag FLAG_SYS_TV_HOME
+        delay 35
+        return
 
 PlayersHouse_1F_Movement_MomApproachDadMale:
 	walk_up


### PR DESCRIPTION
## Summary
- Replace Petalburg Gym report with a news bulletin about a space-time distortion at the Battle Frontier
- Add new player and mom dialogue guiding the player to visit friends after the report
- Update starting-house scripts across regions to use the new news event

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6894f9e54ec08323944378ec2789e0f9