### PR TITLE
Add em dash mapping to charmap

### DIFF
--- a/charmap.txt
+++ b/charmap.txt
@@ -83,6 +83,7 @@ SUPER_RE    = A0
 '.'         = AD
 '-'         = AE
 '_'         = AE @ For autogenerating strings based on label names. Not using {UNDERSCORE} on purpose due to how bad it looks.
+'—'         = AE @ Alias for hyphen to allow use of em dash characters in scripts.
 '·'         = AF
 '…'         = B0
 '“'         = B1


### PR DESCRIPTION
## Summary
- map Unicode em dash to existing hyphen byte in the charmap so event scripts with em dashes assemble

## Testing
- `make -j2` *(fails: Failed to open "graphics/trainers/front_pics/leader_bugsy.png" for reading)*

------
https://chatgpt.com/codex/tasks/task_e_68951f24419483238bb8e609c6b16d4e