### PR TITLE
fix: include name for dynamic region map section

### DIFF
--- a/src/data/region_map/region_map_sections.json
+++ b/src/data/region_map/region_map_sections.json
@@ -785,6 +785,7 @@
     },
     {
       "id": "MAPSEC_DYNAMIC",
+      "name": "",
       "x": 0,
       "y": 0,
       "width": 1,


### PR DESCRIPTION
## Summary
- add empty name string for MAPSEC_DYNAMIC entry in region_map_sections.json

## Testing
- `make src/data/region_map/region_map_entries.h`
- `make include/constants/region_map_sections.h`


------
https://chatgpt.com/codex/tasks/task_e_68956b6cd05c8323aeddbfcb077c2ac5