### PR TITLE
Add progressive item clerks and full TM stock

### DIFF
--- a/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
@@ -25,11 +25,57 @@ LilycoveCity_DepartmentStore_4F_EventScript_ClerkLeft::
 
 	.align 2
 LilycoveCity_DepartmentStore_4F_Pokemart_AttackTMs:
-	.2byte ITEM_TM_FIRE_BLAST
-	.2byte ITEM_TM_THUNDER
-	.2byte ITEM_TM_BLIZZARD
-	.2byte ITEM_TM_HYPER_BEAM
-	pokemartlistend
+        .2byte ITEM_TM01
+        .2byte ITEM_TM02
+        .2byte ITEM_TM03
+        .2byte ITEM_TM04
+        .2byte ITEM_TM05
+        .2byte ITEM_TM06
+        .2byte ITEM_TM07
+        .2byte ITEM_TM08
+        .2byte ITEM_TM09
+        .2byte ITEM_TM10
+        .2byte ITEM_TM11
+        .2byte ITEM_TM12
+        .2byte ITEM_TM13
+        .2byte ITEM_TM14
+        .2byte ITEM_TM15
+        .2byte ITEM_TM16
+        .2byte ITEM_TM17
+        .2byte ITEM_TM18
+        .2byte ITEM_TM19
+        .2byte ITEM_TM20
+        .2byte ITEM_TM21
+        .2byte ITEM_TM22
+        .2byte ITEM_TM23
+        .2byte ITEM_TM24
+        .2byte ITEM_TM25
+        .2byte ITEM_TM26
+        .2byte ITEM_TM27
+        .2byte ITEM_TM28
+        .2byte ITEM_TM29
+        .2byte ITEM_TM30
+        .2byte ITEM_TM31
+        .2byte ITEM_TM32
+        .2byte ITEM_TM33
+        .2byte ITEM_TM34
+        .2byte ITEM_TM35
+        .2byte ITEM_TM36
+        .2byte ITEM_TM37
+        .2byte ITEM_TM38
+        .2byte ITEM_TM39
+        .2byte ITEM_TM40
+        .2byte ITEM_TM41
+        .2byte ITEM_TM42
+        .2byte ITEM_TM43
+        .2byte ITEM_TM44
+        .2byte ITEM_TM45
+        .2byte ITEM_TM46
+        .2byte ITEM_TM47
+        .2byte ITEM_TM48
+        .2byte ITEM_TM49
+        .2byte ITEM_TM50
+        pokemartlistend
 
 LilycoveCity_DepartmentStore_4F_EventScript_ClerkRight::
 	lock
@@ -43,11 +89,57 @@ LilycoveCity_DepartmentStore_4F_EventScript_ClerkRight::
 
 	.align 2
 LilycoveCity_DepartmentStore_4F_Pokemart_DefenseTMs:
-	.2byte ITEM_TM_PROTECT
-	.2byte ITEM_TM_SAFEGUARD
-	.2byte ITEM_TM_REFLECT
-	.2byte ITEM_TM_LIGHT_SCREEN
-	pokemartlistend
+        .2byte ITEM_TM51
+        .2byte ITEM_TM52
+        .2byte ITEM_TM53
+        .2byte ITEM_TM54
+        .2byte ITEM_TM55
+        .2byte ITEM_TM56
+        .2byte ITEM_TM57
+        .2byte ITEM_TM58
+        .2byte ITEM_TM59
+        .2byte ITEM_TM60
+        .2byte ITEM_TM61
+        .2byte ITEM_TM62
+        .2byte ITEM_TM63
+        .2byte ITEM_TM64
+        .2byte ITEM_TM65
+        .2byte ITEM_TM66
+        .2byte ITEM_TM67
+        .2byte ITEM_TM68
+        .2byte ITEM_TM69
+        .2byte ITEM_TM70
+        .2byte ITEM_TM71
+        .2byte ITEM_TM72
+        .2byte ITEM_TM73
+        .2byte ITEM_TM74
+        .2byte ITEM_TM75
+        .2byte ITEM_TM76
+        .2byte ITEM_TM77
+        .2byte ITEM_TM78
+        .2byte ITEM_TM79
+        .2byte ITEM_TM80
+        .2byte ITEM_TM81
+        .2byte ITEM_TM82
+        .2byte ITEM_TM83
+        .2byte ITEM_TM84
+        .2byte ITEM_TM85
+        .2byte ITEM_TM86
+        .2byte ITEM_TM87
+        .2byte ITEM_TM88
+        .2byte ITEM_TM89
+        .2byte ITEM_TM90
+        .2byte ITEM_TM91
+        .2byte ITEM_TM92
+        .2byte ITEM_TM93
+        .2byte ITEM_TM94
+        .2byte ITEM_TM95
+        .2byte ITEM_TM96
+        .2byte ITEM_TM97
+        .2byte ITEM_TM98
+        .2byte ITEM_TM99
+        .2byte ITEM_TM100
+        pokemartlistend
 
 LilycoveCity_DepartmentStore_4F_Text_AttackOrDefenseTM:
 	.string "Hmm…\p"

--- a/data/maps/SlateportCity_Mart/map.json
+++ b/data/maps/SlateportCity_Mart/map.json
@@ -29,6 +29,45 @@
       "flag": "0"
     },
     {
+      "graphics_id": "OBJ_EVENT_GFX_MART_EMPLOYEE",
+      "x": 2,
+      "y": 3,
+      "elevation": 3,
+      "movement_type": "MOVEMENT_TYPE_FACE_RIGHT",
+      "movement_range_x": 0,
+      "movement_range_y": 0,
+      "trainer_type": "TRAINER_TYPE_NONE",
+      "trainer_sight_or_berry_tree_id": "0",
+      "script": "SlateportCity_Mart_EventScript_MegaStoneClerk",
+      "flag": "0"
+    },
+    {
+      "graphics_id": "OBJ_EVENT_GFX_MART_EMPLOYEE",
+      "x": 3,
+      "y": 3,
+      "elevation": 3,
+      "movement_type": "MOVEMENT_TYPE_FACE_RIGHT",
+      "movement_range_x": 0,
+      "movement_range_y": 0,
+      "trainer_type": "TRAINER_TYPE_NONE",
+      "trainer_sight_or_berry_tree_id": "0",
+      "script": "SlateportCity_Mart_EventScript_ZCrystalClerk",
+      "flag": "0"
+    },
+    {
+      "graphics_id": "OBJ_EVENT_GFX_MART_EMPLOYEE",
+      "x": 4,
+      "y": 3,
+      "elevation": 3,
+      "movement_type": "MOVEMENT_TYPE_FACE_RIGHT",
+      "movement_range_x": 0,
+      "movement_range_y": 0,
+      "trainer_type": "TRAINER_TYPE_NONE",
+      "trainer_sight_or_berry_tree_id": "0",
+      "script": "SlateportCity_Mart_EventScript_BattleItemClerk",
+      "flag": "0"
+    },
+    {
       "graphics_id": "OBJ_EVENT_GFX_BLACK_BELT",
       "x": 4,
       "y": 2,

--- a/data/maps/SlateportCity_Mart/scripts.inc
+++ b/data/maps/SlateportCity_Mart/scripts.inc
@@ -13,16 +13,362 @@ SlateportCity_Mart_EventScript_Clerk::
 
 	.align 2
 SlateportCity_Mart_Pokemart:
-	.2byte ITEM_POKE_BALL
-	.2byte ITEM_GREAT_BALL
-	.2byte ITEM_POTION
-	.2byte ITEM_SUPER_POTION
-	.2byte ITEM_ANTIDOTE
-	.2byte ITEM_PARALYZE_HEAL
-	.2byte ITEM_ESCAPE_ROPE
-	.2byte ITEM_REPEL
-	.2byte ITEM_HARBOR_MAIL
-	pokemartlistend
+        .2byte ITEM_POKE_BALL
+        .2byte ITEM_GREAT_BALL
+        .2byte ITEM_POTION
+        .2byte ITEM_SUPER_POTION
+        .2byte ITEM_ANTIDOTE
+        .2byte ITEM_PARALYZE_HEAL
+        .2byte ITEM_ESCAPE_ROPE
+        .2byte ITEM_REPEL
+        .2byte ITEM_HARBOR_MAIL
+        pokemartlistend
+
+SlateportCity_Mart_EventScript_MegaStoneClerk::
+        lock
+        faceplayer
+        message gText_HowMayIServeYou
+        waitmessage
+        goto_if_set FLAG_BADGE08_GET, SlateportCity_Mart_EventScript_MegaStoneClerk_8Badges
+        goto_if_set FLAG_BADGE06_GET, SlateportCity_Mart_EventScript_MegaStoneClerk_6Badges
+        goto_if_set FLAG_BADGE04_GET, SlateportCity_Mart_EventScript_MegaStoneClerk_4Badges
+        goto_if_set FLAG_BADGE02_GET, SlateportCity_Mart_EventScript_MegaStoneClerk_2Badges
+        pokemart SlateportCity_Mart_Pokemart_MegaStones0
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_MegaStoneClerk_2Badges::
+        pokemart SlateportCity_Mart_Pokemart_MegaStones2
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_MegaStoneClerk_4Badges::
+        pokemart SlateportCity_Mart_Pokemart_MegaStones4
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_MegaStoneClerk_6Badges::
+        pokemart SlateportCity_Mart_Pokemart_MegaStones6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_MegaStoneClerk_8Badges::
+        pokemart SlateportCity_Mart_Pokemart_MegaStones6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_ZCrystalClerk::
+        lock
+        faceplayer
+        message gText_HowMayIServeYou
+        waitmessage
+        goto_if_set FLAG_BADGE08_GET, SlateportCity_Mart_EventScript_ZCrystalClerk_8Badges
+        goto_if_set FLAG_BADGE06_GET, SlateportCity_Mart_EventScript_ZCrystalClerk_6Badges
+        goto_if_set FLAG_BADGE04_GET, SlateportCity_Mart_EventScript_ZCrystalClerk_4Badges
+        goto_if_set FLAG_BADGE02_GET, SlateportCity_Mart_EventScript_ZCrystalClerk_2Badges
+        pokemart SlateportCity_Mart_Pokemart_ZCrystals0
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_ZCrystalClerk_2Badges::
+        pokemart SlateportCity_Mart_Pokemart_ZCrystals2
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_ZCrystalClerk_4Badges::
+        pokemart SlateportCity_Mart_Pokemart_ZCrystals4
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_ZCrystalClerk_6Badges::
+        pokemart SlateportCity_Mart_Pokemart_ZCrystals6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_ZCrystalClerk_8Badges::
+        pokemart SlateportCity_Mart_Pokemart_ZCrystals6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_BattleItemClerk::
+        lock
+        faceplayer
+        message gText_HowMayIServeYou
+        waitmessage
+        goto_if_set FLAG_BADGE08_GET, SlateportCity_Mart_EventScript_BattleItemClerk_8Badges
+        goto_if_set FLAG_BADGE06_GET, SlateportCity_Mart_EventScript_BattleItemClerk_6Badges
+        goto_if_set FLAG_BADGE04_GET, SlateportCity_Mart_EventScript_BattleItemClerk_4Badges
+        goto_if_set FLAG_BADGE02_GET, SlateportCity_Mart_EventScript_BattleItemClerk_2Badges
+        pokemart SlateportCity_Mart_Pokemart_BattleItems0
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_BattleItemClerk_2Badges::
+        pokemart SlateportCity_Mart_Pokemart_BattleItems2
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_BattleItemClerk_4Badges::
+        pokemart SlateportCity_Mart_Pokemart_BattleItems4
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_BattleItemClerk_6Badges::
+        pokemart SlateportCity_Mart_Pokemart_BattleItems6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_BattleItemClerk_8Badges::
+        pokemart SlateportCity_Mart_Pokemart_BattleItems6
+        goto SlateportCity_Mart_EventScript_EndShop
+
+SlateportCity_Mart_EventScript_EndShop::
+        msgbox gText_PleaseComeAgain, MSGBOX_DEFAULT
+        release
+        end
+
+        .align 2
+SlateportCity_Mart_Pokemart_MegaStones0:
+        .2byte ITEM_VENUSAURITE
+        .2byte ITEM_CHARIZARDITE_X
+        .2byte ITEM_CHARIZARDITE_Y
+        .2byte ITEM_BLASTOISINITE
+        .2byte ITEM_BEEDRILLITE
+        .2byte ITEM_PIDGEOTITE
+        .2byte ITEM_ALAKAZITE
+        .2byte ITEM_SLOWBRONITE
+        .2byte ITEM_GENGARITE
+        .2byte ITEM_KANGASKHANITE
+        .2byte ITEM_PINSIRITE
+        .2byte ITEM_GYARADOSITE
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_MegaStones2:
+        .2byte ITEM_VENUSAURITE
+        .2byte ITEM_CHARIZARDITE_X
+        .2byte ITEM_CHARIZARDITE_Y
+        .2byte ITEM_BLASTOISINITE
+        .2byte ITEM_BEEDRILLITE
+        .2byte ITEM_PIDGEOTITE
+        .2byte ITEM_ALAKAZITE
+        .2byte ITEM_SLOWBRONITE
+        .2byte ITEM_GENGARITE
+        .2byte ITEM_KANGASKHANITE
+        .2byte ITEM_PINSIRITE
+        .2byte ITEM_GYARADOSITE
+        .2byte ITEM_AERODACTYLITE
+        .2byte ITEM_MEWTWONITE_X
+        .2byte ITEM_MEWTWONITE_Y
+        .2byte ITEM_AMPHAROSITE
+        .2byte ITEM_STEELIXITE
+        .2byte ITEM_SCIZORITE
+        .2byte ITEM_HERACRONITE
+        .2byte ITEM_HOUNDOOMINITE
+        .2byte ITEM_TYRANITARITE
+        .2byte ITEM_SCEPTILITE
+        .2byte ITEM_BLAZIKENITE
+        .2byte ITEM_SWAMPERTITE
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_MegaStones4:
+        .2byte ITEM_VENUSAURITE
+        .2byte ITEM_CHARIZARDITE_X
+        .2byte ITEM_CHARIZARDITE_Y
+        .2byte ITEM_BLASTOISINITE
+        .2byte ITEM_BEEDRILLITE
+        .2byte ITEM_PIDGEOTITE
+        .2byte ITEM_ALAKAZITE
+        .2byte ITEM_SLOWBRONITE
+        .2byte ITEM_GENGARITE
+        .2byte ITEM_KANGASKHANITE
+        .2byte ITEM_PINSIRITE
+        .2byte ITEM_GYARADOSITE
+        .2byte ITEM_AERODACTYLITE
+        .2byte ITEM_MEWTWONITE_X
+        .2byte ITEM_MEWTWONITE_Y
+        .2byte ITEM_AMPHAROSITE
+        .2byte ITEM_STEELIXITE
+        .2byte ITEM_SCIZORITE
+        .2byte ITEM_HERACRONITE
+        .2byte ITEM_HOUNDOOMINITE
+        .2byte ITEM_TYRANITARITE
+        .2byte ITEM_SCEPTILITE
+        .2byte ITEM_BLAZIKENITE
+        .2byte ITEM_SWAMPERTITE
+        .2byte ITEM_GARDEVOIRITE
+        .2byte ITEM_SABLENITE
+        .2byte ITEM_MAWILITE
+        .2byte ITEM_AGGRONITE
+        .2byte ITEM_MEDICHAMITE
+        .2byte ITEM_MANECTITE
+        .2byte ITEM_SHARPEDONITE
+        .2byte ITEM_CAMERUPTITE
+        .2byte ITEM_ALTARIANITE
+        .2byte ITEM_BANETTITE
+        .2byte ITEM_ABSOLITE
+        .2byte ITEM_GLALITITE
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_MegaStones6:
+        .2byte ITEM_VENUSAURITE
+        .2byte ITEM_CHARIZARDITE_X
+        .2byte ITEM_CHARIZARDITE_Y
+        .2byte ITEM_BLASTOISINITE
+        .2byte ITEM_BEEDRILLITE
+        .2byte ITEM_PIDGEOTITE
+        .2byte ITEM_ALAKAZITE
+        .2byte ITEM_SLOWBRONITE
+        .2byte ITEM_GENGARITE
+        .2byte ITEM_KANGASKHANITE
+        .2byte ITEM_PINSIRITE
+        .2byte ITEM_GYARADOSITE
+        .2byte ITEM_AERODACTYLITE
+        .2byte ITEM_MEWTWONITE_X
+        .2byte ITEM_MEWTWONITE_Y
+        .2byte ITEM_AMPHAROSITE
+        .2byte ITEM_STEELIXITE
+        .2byte ITEM_SCIZORITE
+        .2byte ITEM_HERACRONITE
+        .2byte ITEM_HOUNDOOMINITE
+        .2byte ITEM_TYRANITARITE
+        .2byte ITEM_SCEPTILITE
+        .2byte ITEM_BLAZIKENITE
+        .2byte ITEM_SWAMPERTITE
+        .2byte ITEM_GARDEVOIRITE
+        .2byte ITEM_SABLENITE
+        .2byte ITEM_MAWILITE
+        .2byte ITEM_AGGRONITE
+        .2byte ITEM_MEDICHAMITE
+        .2byte ITEM_MANECTITE
+        .2byte ITEM_SHARPEDONITE
+        .2byte ITEM_CAMERUPTITE
+        .2byte ITEM_ALTARIANITE
+        .2byte ITEM_BANETTITE
+        .2byte ITEM_ABSOLITE
+        .2byte ITEM_GLALITITE
+        .2byte ITEM_SALAMENCITE
+        .2byte ITEM_METAGROSSITE
+        .2byte ITEM_LATIASITE
+        .2byte ITEM_LATIOSITE
+        .2byte ITEM_LOPUNNITE
+        .2byte ITEM_GARCHOMPITE
+        .2byte ITEM_LUCARIONITE
+        .2byte ITEM_ABOMASITE
+        .2byte ITEM_GALLADITE
+        .2byte ITEM_AUDINITE
+        .2byte ITEM_DIANCITE
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_ZCrystals0:
+        .2byte ITEM_NORMALIUM_Z
+        .2byte ITEM_FIRIUM_Z
+        .2byte ITEM_WATERIUM_Z
+        .2byte ITEM_ELECTRIUM_Z
+        .2byte ITEM_GRASSIUM_Z
+        .2byte ITEM_ICIUM_Z
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_ZCrystals2:
+        .2byte ITEM_NORMALIUM_Z
+        .2byte ITEM_FIRIUM_Z
+        .2byte ITEM_WATERIUM_Z
+        .2byte ITEM_ELECTRIUM_Z
+        .2byte ITEM_GRASSIUM_Z
+        .2byte ITEM_ICIUM_Z
+        .2byte ITEM_FIGHTINIUM_Z
+        .2byte ITEM_POISONIUM_Z
+        .2byte ITEM_GROUNDIUM_Z
+        .2byte ITEM_FLYINIUM_Z
+        .2byte ITEM_PSYCHIUM_Z
+        .2byte ITEM_BUGINIUM_Z
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_ZCrystals4:
+        .2byte ITEM_NORMALIUM_Z
+        .2byte ITEM_FIRIUM_Z
+        .2byte ITEM_WATERIUM_Z
+        .2byte ITEM_ELECTRIUM_Z
+        .2byte ITEM_GRASSIUM_Z
+        .2byte ITEM_ICIUM_Z
+        .2byte ITEM_FIGHTINIUM_Z
+        .2byte ITEM_POISONIUM_Z
+        .2byte ITEM_GROUNDIUM_Z
+        .2byte ITEM_FLYINIUM_Z
+        .2byte ITEM_PSYCHIUM_Z
+        .2byte ITEM_BUGINIUM_Z
+        .2byte ITEM_ROCKIUM_Z
+        .2byte ITEM_GHOSTIUM_Z
+        .2byte ITEM_DRAGONIUM_Z
+        .2byte ITEM_DARKINIUM_Z
+        .2byte ITEM_STEELIUM_Z
+        .2byte ITEM_FAIRIUM_Z
+        .2byte ITEM_PIKANIUM_Z
+        .2byte ITEM_EEVIUM_Z
+        .2byte ITEM_SNORLIUM_Z
+        .2byte ITEM_MEWNIUM_Z
+        .2byte ITEM_DECIDIUM_Z
+        .2byte ITEM_INCINIUM_Z
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_ZCrystals6:
+        .2byte ITEM_NORMALIUM_Z
+        .2byte ITEM_FIRIUM_Z
+        .2byte ITEM_WATERIUM_Z
+        .2byte ITEM_ELECTRIUM_Z
+        .2byte ITEM_GRASSIUM_Z
+        .2byte ITEM_ICIUM_Z
+        .2byte ITEM_FIGHTINIUM_Z
+        .2byte ITEM_POISONIUM_Z
+        .2byte ITEM_GROUNDIUM_Z
+        .2byte ITEM_FLYINIUM_Z
+        .2byte ITEM_PSYCHIUM_Z
+        .2byte ITEM_BUGINIUM_Z
+        .2byte ITEM_ROCKIUM_Z
+        .2byte ITEM_GHOSTIUM_Z
+        .2byte ITEM_DRAGONIUM_Z
+        .2byte ITEM_DARKINIUM_Z
+        .2byte ITEM_STEELIUM_Z
+        .2byte ITEM_FAIRIUM_Z
+        .2byte ITEM_PIKANIUM_Z
+        .2byte ITEM_EEVIUM_Z
+        .2byte ITEM_SNORLIUM_Z
+        .2byte ITEM_MEWNIUM_Z
+        .2byte ITEM_DECIDIUM_Z
+        .2byte ITEM_INCINIUM_Z
+        .2byte ITEM_PRIMARIUM_Z
+        .2byte ITEM_LYCANIUM_Z
+        .2byte ITEM_MIMIKIUM_Z
+        .2byte ITEM_KOMMONIUM_Z
+        .2byte ITEM_TAPUNIUM_Z
+        .2byte ITEM_SOLGANIUM_Z
+        .2byte ITEM_LUNALIUM_Z
+        .2byte ITEM_MARSHADIUM_Z
+        .2byte ITEM_ALORAICHIUM_Z
+        .2byte ITEM_PIKASHUNIUM_Z
+        .2byte ITEM_ULTRANECROZIUM_Z
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_BattleItems0:
+        .2byte ITEM_CHOICE_BAND
+        .2byte ITEM_CHOICE_SPECS
+        .2byte ITEM_CHOICE_SCARF
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_BattleItems2:
+        .2byte ITEM_CHOICE_BAND
+        .2byte ITEM_CHOICE_SPECS
+        .2byte ITEM_CHOICE_SCARF
+        .2byte ITEM_LIFE_ORB
+        .2byte ITEM_LEFTOVERS
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_BattleItems4:
+        .2byte ITEM_CHOICE_BAND
+        .2byte ITEM_CHOICE_SPECS
+        .2byte ITEM_CHOICE_SCARF
+        .2byte ITEM_LIFE_ORB
+        .2byte ITEM_LEFTOVERS
+        .2byte ITEM_FOCUS_SASH
+        .2byte ITEM_ROCKY_HELMET
+        pokemartlistend
+
+SlateportCity_Mart_Pokemart_BattleItems6:
+        .2byte ITEM_CHOICE_BAND
+        .2byte ITEM_CHOICE_SPECS
+        .2byte ITEM_CHOICE_SCARF
+        .2byte ITEM_LIFE_ORB
+        .2byte ITEM_LEFTOVERS
+        .2byte ITEM_FOCUS_SASH
+        .2byte ITEM_ROCKY_HELMET
+        .2byte ITEM_WEAKNESS_POLICY
+        .2byte ITEM_ASSAULT_VEST
+        pokemartlistend
 
 SlateportCity_Mart_EventScript_BlackBelt::
 	msgbox SlateportCity_Mart_Text_SomeItemsOnlyAtMart, MSGBOX_NPC


### PR DESCRIPTION
## Summary
- Add Mega Stone, Z-Crystal, and battle item clerks to Slateport Mart with badge-based inventory expansion
- Expand Lilycove Dept. Store TM counters to sell every TM
- Fix TM constant names in Lilycove Dept. Store script to resolve build errors

## Testing
- `make -j4` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956196bd08832390d0fe1321b8ec78