### PR TITLE
Fix rocket grunt palettes and berry tree references

### DIFF
--- a/src/data/object_events/object_event_graphics.h
+++ b/src/data/object_events/object_event_graphics.h
@@ -397,8 +397,8 @@ const u16 gObjectEventPal_Substitute[] = INCBIN_U16("graphics/object_events/pics
 const u16 gObjectEventPaletteEmotes[] = INCBIN_U16("graphics/misc/emotes.gbapal");
 const u16 gObjectEventPaletteNeonLight[] = INCBIN_U16("graphics/object_events/palettes/neon_light.gbapal");
 
-const u16 gObjectEventPal_RocketGruntM[] = INCBIN_U16("graphics/object_events/palettes/rocketgruntm.pal");
-const u16 gObjectEventPal_RocketGruntF[] = INCBIN_U16("graphics/object_events/palettes/rocketgruntf.pal");
+const u16 gObjectEventPal_RocketGruntM[] = INCBIN_U16("graphics/object_events/palettes/rocketgruntm.gbapal");
+const u16 gObjectEventPal_RocketGruntF[] = INCBIN_U16("graphics/object_events/palettes/rocketgruntf.gbapal");
 
 //Platinum
 

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -220,8 +220,6 @@ static void CopyObjectGraphicsInfoToSpriteTemplate_WithMovementType(u16 graphics
 static u16 GetGraphicsIdForMon(u32 species, bool32 shiny, bool32 female);
 static u16 GetUnownSpecies(struct Pokemon *mon);
 
-static const struct SpriteFrameImage sPicTable_PechaBerryTree[];
-
 static void StartSlowRunningAnim(struct ObjectEvent *objectEvent, struct Sprite *sprite, u8 direction);
 
 const u8 gReflectionEffectPaletteMap[16] = {
@@ -479,14 +477,15 @@ const u8 gInitialMovementTypeFacingDirections[NUM_MOVEMENT_TYPES] = {
     [MOVEMENT_TYPE_FOLLOW_PLAYER] = DIR_SOUTH,
 };
 
-#include "data/object_events/object_event_graphics_info_pointers.h"
 #include "data/field_effects/field_effect_object_template_pointers.h"
 #include "data/object_events/object_event_pic_tables.h"
 #include "data/object_events/object_event_anims.h"
 #include "data/object_events/base_oam.h"
 #include "data/object_events/object_event_subsprites.h"
+#include "data/object_events/berry_tree_graphics_tables.h"
 #include "data/object_events/object_event_graphics_info.h"
 #include "data/object_events/object_event_graphics_info_followers.h"
+#include "data/object_events/object_event_graphics_info_pointers.h"
 
 static const struct SpritePalette sObjectEventSpritePalettes[] = {
     {gObjectEventPal_Npc1,                  OBJ_EVENT_PAL_TAG_NPC_1},
@@ -818,7 +817,6 @@ static const u16 *const sObjectPaletteTagSets[] = {
     sObjectPaletteTags3,
 };
 
-#include "data/object_events/berry_tree_graphics_tables.h"
 #include "data/field_effects/field_effect_objects.h"
 
 static const s16 sMovementDelaysMedium[] = {32, 64,  96, 128};

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -259,8 +259,6 @@ static void (*const sCameraObjectFuncs[])(struct Sprite *) = {
     [CAMERA_STATE_FROZEN] = CameraObject_UpdateFrozen,
 };
 
-#include "data/object_events/object_event_graphics.h"
-
 // movement type callbacks
 static void (*const sMovementTypeCallbacks[])(struct Sprite *) =
 {
@@ -478,6 +476,7 @@ const u8 gInitialMovementTypeFacingDirections[NUM_MOVEMENT_TYPES] = {
 };
 
 #include "data/field_effects/field_effect_object_template_pointers.h"
+#include "data/object_events/object_event_graphics.h"
 #include "data/object_events/object_event_pic_tables.h"
 #include "data/object_events/object_event_anims.h"
 #include "data/object_events/base_oam.h"


### PR DESCRIPTION
## Summary
- Use binary palette files for Rocket Grunt sprites
- Include berry tree graphics before object event graphics data and clean up unused declaration

## Testing
- `make -C . build/modern/src/event_object_movement.o`


------
https://chatgpt.com/codex/tasks/task_e_68962276a2e88323970e56af69097851