### PR TITLE
Fix Wormhole encounter script delay command

### DIFF
--- a/data/maps/OldaleTown/scripts.inc
+++ b/data/maps/OldaleTown/scripts.inc
@@ -621,7 +621,7 @@ OldaleTown_EventScript_WormholeEncounter::
         clearflag FLAG_HIDE_OLDALE_ROCKET_GRUNT
         addobject LOCALID_OLDALE_WORMHOLE
         addobject LOCALID_OLDALE_ROCKET_GRUNT
-        wait 32
+        delay 32
         msgbox OldaleTown_Text_RocketMutter, MSGBOX_NPC
         applymovement LOCALID_OLDALE_ROCKET_GRUNT, OldaleTown_Movement_RocketExit
         waitmovement 0


### PR DESCRIPTION
## Summary
- use the correct `delay` command in Oldale Town's wormhole encounter script

## Testing
- `make modern -j4` *(fails: `arm-none-eabi-gcc: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6896300c19a88323a312c6e804ccb658