### PR TITLE
Avoid soft reset when battle data swap fails

### DIFF
--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -6890,11 +6890,7 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
     u32 battlerAtk = gBattlerAttacker;
     u32 battlerPartner = BATTLE_PARTNER(battlerAtk);
 
-    void *data = Alloc(0x200);
-    if (data == NULL)
-    {
-        SoftReset(1);
-    }
+    u8 data[0x200];
 
     SwapStructData(&gBattleMons[battlerAtk], &gBattleMons[battlerPartner], data, sizeof(struct BattlePokemon));
     SwapStructData(&gDisableStructs[battlerAtk], &gDisableStructs[battlerPartner], data, sizeof(struct DisableStruct));
@@ -6959,8 +6955,6 @@ static void AnimTask_AllySwitchDataSwap(u8 taskId)
         ReloadBattlerSprites(battlerPartner, party);
         ReloadBattlerSprites(battlerAtk, party);
     }
-
-    Free(data);
 
     gBattleScripting.battler = battlerPartner;
     DestroyAnimVisualTask(taskId);


### PR DESCRIPTION
## Summary
- prevent battle data swap from triggering a soft reset if memory allocation fails by using a stack buffer instead of `Alloc`

## Testing
- `make check -j4`

------
https://chatgpt.com/codex/tasks/task_e_689659cb1af4832389c9c5360b268120