### PR TITLE
Replace unsupported em dashes in map scripts

### DIFF
--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -307,7 +307,7 @@ PlayersHouse_1F_Text_GoSetTheClock:
 	.string "Go set the clock in your room, honey.$"
 
 PlayersHouse_1F_Text_OhComeQuickly:
-        .string "MOM: {PLAYER}! Hurry, come watch—there's\n"
+        .string "MOM: {PLAYER}! Hurry, come watch--there's\n"
         .string "something strange on the news!$"
 
 PlayersHouse_1F_Text_ItsOverWeMissedHim:
@@ -324,7 +324,7 @@ PlayersHouse_1F_Text_GladYoureBack:
 
 PlayersHouse_1F_Text_GoIntroduceYourselfNextDoor:
         .string "MOM: Why don't you go say hello?\n"
-        .string "I think MAY's next door—or maybe\l"
+        .string "I think MAY's next door--or maybe\l"
         .string "BRENDAN's out on ROUTE 103.$"
 
 PlayersHouse_1F_Text_SeeYouHoney:
@@ -388,7 +388,7 @@ PlayersHouse_1F_Text_BattleFrontierNews4:
 
 PlayersHouse_1F_Text_BattleFrontierNews5:
         .string "REPORTER: An interregional gate has\n"
-        .string "appeared where the entrance once stood—\l"
+        .string "appeared where the entrance once stood--\l"
         .string "and it leads to both JOHTO and KANTO.$"
 
 PlayersHouse_1F_Text_BattleFrontierNews6:
@@ -397,7 +397,7 @@ PlayersHouse_1F_Text_BattleFrontierNews6:
         .string "their efforts to stabilize the anomaly.$"
 
 PlayersHouse_1F_Text_BattleFrontierNews7:
-        .string "REPORTER: Assisting them is COLRESS—\n"
+        .string "REPORTER: Assisting them is COLRESS--\n"
         .string "the brilliant scientist formerly\l"
         .string "associated with UNOVA's PLASMA\l"
         .string "FOUNDATION.$"

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -700,22 +700,22 @@ LittlerootTown_ProfessorBirchsLab_Text_BirchEnjoysRivalsHelpToo:
 	.string "There's a lot of love there.$"
 
 LittlerootTown_ProfessorBirchsLab_Text_BirchRecognizesPlayer:
-	.string "PROF. BIRCH: Ah—there you are. About\n"
+        .string "PROF. BIRCH: Ah--there you are. About\n"
 	.string "that field incident… Wait, is that\l"
-	.string "you, {PLAYER}? I'll be—look at you!\p"
+        .string "you, {PLAYER}? I'll be--look at you!\p"
 	.string "It's been years. No wonder you handled\n"
 	.string "that so calmly.$"
 
 LittlerootTown_ProfessorBirchsLab_Text_PlayerMentionsDistortions:
 	.string "{PLAYER}: It's good to see you too,\n"
 	.string "PROFESSOR. I heard about the\l"
-	.string "distortions—the Gate at the BATTLE\n"
+        .string "distortions--the Gate at the BATTLE\n"
 	.string "FRONTIER. Is HOENN really linked to\l"
 	.string "JOHTO and KANTO?$"
 
 LittlerootTown_ProfessorBirchsLab_Text_BirchExplainsTear:
 	.string "PROF. BIRCH: The readings confirm a\n"
-	.string "tear—stable, but volatile. DEVON and\l"
+        .string "tear--stable, but volatile. DEVON and\l"
 	.string "SILPH are monitoring it with a visiting\n"
 	.string "scientist named COLRESS. Habitats are\l"
 	.string "shifting; some TRAINERS are reporting\n"
@@ -727,7 +727,7 @@ LittlerootTown_ProfessorBirchsLab_Text_PlayerOffersHelp:
 	.string "you whatever data you need.$"
 
 LittlerootTown_ProfessorBirchsLab_Text_BirchGivesPokemon:
-	.string "PROF. BIRCH: Keep it—consider that\n"
+        .string "PROF. BIRCH: Keep it--consider that\n"
 	.string "POKéMON your partner.\p"
 	.string "{PLAYER} received the {STR_VAR_1}!$"
 
@@ -740,7 +740,7 @@ LittlerootTown_ProfessorBirchsLab_Text_MightBeGoodIdeaToGoSeeRival:
         .string "{RIVAL}. I asked them to run a quick\l"
         .string "field assessment. Show me you can\n"
         .string "coordinate with your partner in a real\l"
-        .string "battle—no shortcuts, no gimmicks.\p"
+        .string "battle--no shortcuts, no gimmicks.\p"
         .string "Defeat {RIVAL} and then report back\n"
         .string "here. Once I know you're ready, I'll\l"
         .string "equip you properly and brief you on the\n"
@@ -752,7 +752,7 @@ LittlerootTown_ProfessorBirchsLab_Text_PlayerUnderstands:
 	.string "we're ready.$"
 LittlerootTown_ProfessorBirchsLab_Text_GetRivalToTeachYou:
         .string "PROF. BIRCH: Good. Keep your eyes open\n"
-        .string "for unusual readings on the way—odd\l"
+        .string "for unusual readings on the way--odd\l"
         .string "cries, time-of-day shifts, anything.\p"
         .string "I'll finalize your gear once you're\n"
         .string "back.$"

--- a/data/maps/OldaleTown/scripts.inc
+++ b/data/maps/OldaleTown/scripts.inc
@@ -592,10 +592,10 @@ OldaleTown_Text_RocketMutter:
         .string "...Where the hell am I? This isn't Goldenrod... tch.$"
 
 OldaleTown_Text_PlayerThought:
-        .string "That 'R'... it looks oddly familiar... Where have I—$"
+        .string "That 'R'... it looks oddly familiar... Where have I--$"
 
 OldaleTown_Text_TwinChallenge:
-        .string "Wait—{PLAYER}?! No way! It's been forever! You're here? You have to battle me right now!$"
+        .string "Wait--{PLAYER}?! No way! It's been forever! You're here? You have to battle me right now!$"
 
 OldaleTown_Text_TwinAfterBattle:
         .string "Hah! That was great... but... did you see something just now?$"

--- a/data/maps/Route101/scripts.inc
+++ b/data/maps/Route101/scripts.inc
@@ -264,7 +264,7 @@ Route101_Text_PleaseHelp:
         .string "You there! I came to follow a strange\n"
         .string "reading near the BATTLE FRONTIER GATE\p"
         .string "and… This wild POKéMON won't let me move!\n"
-        .string "Quick—use one of those POKé BALLS!$"
+        .string "Quick--use one of those POKé BALLS!$"
 
 Route101_Text_DontLeaveMe:
 	.string "Wh-Where are you going?!\n"
@@ -274,7 +274,7 @@ Route101_Text_YouSavedMe:
         .string "PROF. BIRCH: Whew… That was too close.\p"
         .string "Those energy spikes have the local\n"
         .string "wilds on edge. I shouldn't have come\p"
-        .string "alone. Thank you—really.\p"
+        .string "alone. Thank you--really.\p"
         .string "Let's get back to the LAB where it's\n"
         .string "safer. I need to check this data.\p"
         .string "Come with me.$"


### PR DESCRIPTION
## Summary
- replace em dash characters in route and town scripts with ASCII double hyphens

## Testing
- `make -j4` *(fails: Failed to open "graphics/object_events/pics/pokemon/hooparing.png" for reading)*

------
https://chatgpt.com/codex/tasks/task_e_6896bac4831c8323b1503f97772e03ab