### PR TITLE
Add stubs for missing map and tileset symbols

### DIFF
--- a/src/map_data_stubs.c
+++ b/src/map_data_stubs.c
@@ -1,0 +1,21 @@
+#include "global.h"
+
+// Stub definitions to satisfy linker when map and tileset data are missing.
+
+// Placeholder map layouts table
+const struct MapLayout *const gMapLayouts[] = { NULL };
+
+// Placeholder map groups table
+const struct MapHeader *const *const gMapGroups[] = { NULL };
+
+// Secret Base tileset pointers used by decoration and field effects
+const struct Tileset *const gTilesetPointer_SecretBase = NULL;
+const struct Tileset *const gTilesetPointer_SecretBaseRedCave = NULL;
+
+// Tileset definitions referenced by various overworld routines
+const struct Tileset gTileset_Building = {0};
+const struct Tileset gTileset_BrendansMaysHouse = {0};
+
+// Secret Base palette table referenced by field effects
+const u16 gTilesetPalettes_SecretBase[][16] = { {0} };
+


### PR DESCRIPTION
## Summary
- Provide placeholder definitions for map layout and group tables
- Stub out Secret Base tileset pointers, tilesets, and palettes so build can link

## Testing
- `make test` *(fails: arm-none-eabi-gcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896be3c114c8323b36b116685d40988