### PR TITLE
Fix crash during gender selection

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -1308,6 +1308,7 @@ static void Task_NewGameBirchSpeech_Init(u8 taskId)
     gTasks[taskId].tBG1HOFS = 0;
     gTasks[taskId].func = Task_NewGameBirchSpeech_WaitToShowBirch;
     gTasks[taskId].tPlayerSpriteId = SPRITE_NONE;
+    gTasks[taskId].tPlayerGender = MALE;
     gTasks[taskId].data[3] = 0xFF;
     gTasks[taskId].tTimer = 0xD8;
     PlayBGM(MUS_ROUTE122);
@@ -1539,7 +1540,7 @@ static void Task_NewGameBirchSpeech_ChooseGender(u8 taskId)
             break;
     }
     gender2 = Menu_GetCursorPos();
-    if (gender2 != gTasks[taskId].tPlayerGender)
+    if (gTasks[taskId].tPlayerSpriteId != SPRITE_NONE && gender2 != gTasks[taskId].tPlayerGender)
     {
         gTasks[taskId].tPlayerGender = gender2;
         gSprites[gTasks[taskId].tPlayerSpriteId].oam.objMode = ST_OAM_OBJ_BLEND;


### PR DESCRIPTION
## Summary
- prevent access to invalid gender sprite
- initialize default gender state during intro

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6896c1b4ba8c8323b8d5434784ab33af