### PR TITLE
Fix map data stub multiple definitions

### DIFF
--- a/src/map_data_stubs.c
+++ b/src/map_data_stubs.c
@@ -3,19 +3,19 @@
 // Stub definitions to satisfy linker when map and tileset data are missing.
 
 // Placeholder map layouts table
-const struct MapLayout *const gMapLayouts[] = { NULL };
+const struct MapLayout *const gMapLayouts[] __attribute__((weak)) = { NULL };
 
 // Placeholder map groups table
-const struct MapHeader *const *const gMapGroups[] = { NULL };
+const struct MapHeader *const *const gMapGroups[] __attribute__((weak)) = { NULL };
 
 // Secret Base tileset pointers used by decoration and field effects
-const struct Tileset *const gTilesetPointer_SecretBase = NULL;
-const struct Tileset *const gTilesetPointer_SecretBaseRedCave = NULL;
+const struct Tileset *const gTilesetPointer_SecretBase __attribute__((weak)) = NULL;
+const struct Tileset *const gTilesetPointer_SecretBaseRedCave __attribute__((weak)) = NULL;
 
 // Tileset definitions referenced by various overworld routines
-const struct Tileset gTileset_Building = {0};
-const struct Tileset gTileset_BrendansMaysHouse = {0};
+const struct Tileset gTileset_Building __attribute__((weak)) = {0};
+const struct Tileset gTileset_BrendansMaysHouse __attribute__((weak)) = {0};
 
 // Secret Base palette table referenced by field effects
-const u16 gTilesetPalettes_SecretBase[][16] = { {0} };
+const u16 gTilesetPalettes_SecretBase[][16] __attribute__((weak)) = { {0} };
 


### PR DESCRIPTION
## Summary
- mark map layout and tileset stubs as weak so real map data can override them

## Testing
- `make -j4` *(fails: Failed to open "graphics/object_events/pics/pokemon/hooparing.png" for reading)*

------
https://chatgpt.com/codex/tasks/task_e_6897612594e083238f62a7990a4bd66f